### PR TITLE
fixes a bug when the first two nframes are complete

### DIFF
--- a/aslam_cv_pipeline/src/visual-npipeline.cc
+++ b/aslam_cv_pipeline/src/visual-npipeline.cc
@@ -220,7 +220,6 @@ void VisualNPipeline::work(size_t camera_index, const cv::Mat& image, int64_t ti
         }
         if (num_consecutive_complete >= kNumMinConsecutiveCompleteThreshold) {
           delete_upto_including_index = idx - kNumMinConsecutiveCompleteThreshold;
-          CHECK_GE(delete_upto_including_index, 0);
           break;
         }
         ++it_processing;


### PR DESCRIPTION
This check fails in the following legitimate scenario:
```
C C C C
0 1 2 3
```
In this case (the first two frames are complete), the if-block on line 221 evaluates to true, with `num_consecutive_complete == 2` and `idx == 1`, leading to `delete_upto_including_index` being set to `-1`, triggering the check-fail.
It being set to `-1` is, however, correct in this case (one index before the first of the complete frames), and is handles correctly in line 233: Nothing is deleted.
Hence: The check is wrongly in place and should go away. 