### PR TITLE
only waiting for one complete nframe

### DIFF
--- a/aslam_cv_pipeline/include/aslam/pipeline/visual-npipeline.h
+++ b/aslam_cv_pipeline/include/aslam/pipeline/visual-npipeline.h
@@ -204,6 +204,10 @@ class VisualNPipeline final {
 
   /// The tolerance for associating host timestamps as being captured at the same time
   int64_t timestamp_tolerance_ns_;
+
+  // The minimum number of consecutive complete nframes required for dropping older incomplete
+  // nframes.
+  const size_t min_num_consecutive_complete_nframes_threshold_;
 };
 }  // namespace aslam
 #endif // VISUAL_NPIPELINE_H_

--- a/aslam_cv_pipeline/src/visual-npipeline.cc
+++ b/aslam_cv_pipeline/src/visual-npipeline.cc
@@ -276,7 +276,7 @@ void VisualNPipeline::work(size_t camera_index, const cv::Mat& image,
     // E.g. N=3    I I C I C C C C C   (I: incomplete, C: complete)
     //      idx    0 1 2 3 4 5 6 7 8
     //                     # --> first index with N complete = 4
-    const size_t kNumMinConsecutiveCompleteThreshold = 2u;
+    const size_t kNumMinConsecutiveCompleteThreshold = 1u;
     int delete_upto_including_index = -1;
     if (processing_.size() > kNumMinConsecutiveCompleteThreshold + 1) {
       size_t num_consecutive_complete = 0u;


### PR DESCRIPTION
This whole "drop incomplete nframes" logic is base on the assumption of monotonically increasing timestamps within every image topic (i.e., image messages of the same topic can not "overtake" each other).
Therefore, I don't see any reason at all why one should wait for more than one complete nframe before dropping all incomplete older nframes (because given the assumption above, they can't every be completed anyways). 
Hence the switch from 2 to 1.