### PR TITLE
Fix unit test which failed on ARM.

### DIFF
--- a/aslam_cv_calibration/include/aslam/calibration/target-observation.h
+++ b/aslam_cv_calibration/include/aslam/calibration/target-observation.h
@@ -69,7 +69,7 @@ class TargetObservation {
   }
 
   Eigen::Vector2d getObservedCorner(size_t idx) const {
-    CHECK_LT(idx, image_corners_.cols());
+    CHECK_LT(idx, static_cast<size_t>(image_corners_.cols()));
     return image_corners_.col(idx);
   }
 

--- a/aslam_cv_tracker/test/test-track-manager.cc
+++ b/aslam_cv_tracker/test/test-track-manager.cc
@@ -150,10 +150,10 @@ TEST(TrackManagerTests, TestApplyMatchesUniformly) {
 
   for (size_t idx = 1; idx <= half_num_keypoints; ++idx) {
     double x = image_width -
-        (image_width /
-            static_cast<double>(half_num_keypoints) * static_cast<double>(idx));
-    double y = image_height /
-        static_cast<double>(half_num_keypoints + 1) * static_cast<double>(idx);
+               (image_width / static_cast<double>(half_num_keypoints + 1) *
+                static_cast<double>(idx));
+    double y = image_height / static_cast<double>(half_num_keypoints + 1) *
+               static_cast<double>(idx);
     CHECK_GE(x, 0.0); CHECK_LE(x, image_width);
     CHECK_GE(y, 0.0); CHECK_LT(y, image_height);
 

--- a/aslam_cv_tracker/test/test-track-manager.cc
+++ b/aslam_cv_tracker/test/test-track-manager.cc
@@ -150,9 +150,9 @@ TEST(TrackManagerTests, TestApplyMatchesUniformly) {
 
   for (size_t idx = 1; idx <= half_num_keypoints; ++idx) {
     double x = image_width -
-               (image_width / static_cast<double>(half_num_keypoints + 1) *
+               (image_width / static_cast<double>(half_num_keypoints + 1u) *
                 static_cast<double>(idx));
-    double y = image_height / static_cast<double>(half_num_keypoints + 1) *
+    double y = image_height / static_cast<double>(half_num_keypoints + 1u) *
                static_cast<double>(idx);
     CHECK_GE(x, 0.0); CHECK_LE(x, image_width);
     CHECK_GE(y, 0.0); CHECK_LT(y, image_height);


### PR DESCRIPTION
The following check failed on ARM processors:
```bash
F0110 16:51:40.900504 31754 test-track-manager.cc:161] Check failed: x >= 0.0 (-3.55271e-14 vs. 0)
```

The problem was the numeric accuracy of the x values of the "bottom left to top right" keypoints which didn't sum up to 0.0 in the end (probably to some optimizations which sacrifice some accuracy).