### PR TITLE
Fix/keypoint matcher search radius

### DIFF
--- a/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
+++ b/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
@@ -101,7 +101,7 @@ class GyroTwoFrameMatcher {
 
   void getKeypointIteratorsInWindow(
       const Eigen::Vector2d& predicted_keypoint_position,
-      const int window_half_side_length,
+      const int window_half_side_length_px,
       KeyPointIterator* it_keypoints_begin,
       KeyPointIterator* it_keypoints_end) const;
 
@@ -195,11 +195,12 @@ class GyroTwoFrameMatcher {
 
 void GyroTwoFrameMatcher::getKeypointIteratorsInWindow(
     const Eigen::Vector2d& predicted_keypoint_position,
-    const int window_half_side_length,
+    const int window_half_side_length_px,
     KeyPointIterator* it_keypoints_begin,
     KeyPointIterator* it_keypoints_end) const {
   CHECK_NOTNULL(it_keypoints_begin);
   CHECK_NOTNULL(it_keypoints_end);
+CHECK_GT(window_half_side_length_px, 0);
 
   // Compute search area for LUT iterators row-wise.
   int LUT_index_top = clamp(0, kImageHeight - 1, static_cast<int>(

--- a/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
+++ b/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
@@ -204,9 +204,9 @@ CHECK_GT(window_half_side_length_px, 0);
 
   // Compute search area for LUT iterators row-wise.
   int LUT_index_top = clamp(0, kImageHeight - 1, static_cast<int>(
-      predicted_keypoint_position(1) + 0.5 - window_half_side_length));
+      predicted_keypoint_position(1) + 0.5 - window_half_side_length_px));
   int LUT_index_bottom = clamp(0, kImageHeight - 1, static_cast<int>(
-      predicted_keypoint_position(1) + 0.5 + window_half_side_length));
+      predicted_keypoint_position(1) + 0.5 + window_half_side_length_px));
 
   *it_keypoints_begin = keypoints_kp1_sorted_by_y_.begin() + corner_row_LUT_[LUT_index_top];
   *it_keypoints_end = keypoints_kp1_sorted_by_y_.begin() + corner_row_LUT_[LUT_index_bottom];

--- a/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
+++ b/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
@@ -101,7 +101,7 @@ class GyroTwoFrameMatcher {
 
   void getKeypointIteratorsInWindow(
       const Eigen::Vector2d& predicted_keypoint_position,
-      const int WindowHalfSideLength,
+      const int window_half_side_length,
       KeyPointIterator* it_keypoints_begin,
       KeyPointIterator* it_keypoints_end) const;
 
@@ -185,17 +185,17 @@ class GyroTwoFrameMatcher {
   // Two descriptors could match if they pass the Lowe ratio test.
   static constexpr float kLoweRatio = 0.8f;
   // Small image space distances for keypoint matches.
-  const int kSmallSearchDistance;
+  const int small_search_distance_px_;
   // Large image space distances for keypoint matches.
   // Only used if small search was unsuccessful.
-  const int kLargeSearchDistance;
+  const int large_search_distance_px_;
   // Number of iterations to match inferior matches.
   static constexpr size_t kMaxNumInferiorIterations = 3u;
 };
 
 void GyroTwoFrameMatcher::getKeypointIteratorsInWindow(
     const Eigen::Vector2d& predicted_keypoint_position,
-    const int WindowHalfSideLength,
+    const int window_half_side_length,
     KeyPointIterator* it_keypoints_begin,
     KeyPointIterator* it_keypoints_end) const {
   CHECK_NOTNULL(it_keypoints_begin);
@@ -203,9 +203,9 @@ void GyroTwoFrameMatcher::getKeypointIteratorsInWindow(
 
   // Compute search area for LUT iterators row-wise.
   int LUT_index_top = clamp(0, kImageHeight - 1, static_cast<int>(
-      predicted_keypoint_position(1) + 0.5 - WindowHalfSideLength));
+      predicted_keypoint_position(1) + 0.5 - window_half_side_length));
   int LUT_index_bottom = clamp(0, kImageHeight - 1, static_cast<int>(
-      predicted_keypoint_position(1) + 0.5 + WindowHalfSideLength));
+      predicted_keypoint_position(1) + 0.5 + window_half_side_length));
 
   *it_keypoints_begin = keypoints_kp1_sorted_by_y_.begin() + corner_row_LUT_[LUT_index_top];
   *it_keypoints_end = keypoints_kp1_sorted_by_y_.begin() + corner_row_LUT_[LUT_index_bottom];

--- a/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
+++ b/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
@@ -99,9 +99,9 @@ class GyroTwoFrameMatcher {
   /// already existing match.
   void matchKeypoint(const int idx_k);
 
-  template <int WindowHalfSideLength>
   void getKeypointIteratorsInWindow(
       const Eigen::Vector2d& predicted_keypoint_position,
+      const int WindowHalfSideLength,
       KeyPointIterator* it_keypoints_begin,
       KeyPointIterator* it_keypoints_end) const;
 
@@ -185,17 +185,17 @@ class GyroTwoFrameMatcher {
   // Two descriptors could match if they pass the Lowe ratio test.
   static constexpr float kLoweRatio = 0.8f;
   // Small image space distances for keypoint matches.
-  int kSmallSearchDistance;
+  const int kSmallSearchDistance;
   // Large image space distances for keypoint matches.
   // Only used if small search was unsuccessful.
-  int kLargeSearchDistance;
+  const int kLargeSearchDistance;
   // Number of iterations to match inferior matches.
   static constexpr size_t kMaxNumInferiorIterations = 3u;
 };
 
-template <int WindowHalfSideLength>
 void GyroTwoFrameMatcher::getKeypointIteratorsInWindow(
     const Eigen::Vector2d& predicted_keypoint_position,
+    const int WindowHalfSideLength,
     KeyPointIterator* it_keypoints_begin,
     KeyPointIterator* it_keypoints_end) const {
   CHECK_NOTNULL(it_keypoints_begin);

--- a/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
+++ b/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
@@ -185,10 +185,10 @@ class GyroTwoFrameMatcher {
   // Two descriptors could match if they pass the Lowe ratio test.
   static constexpr float kLoweRatio = 0.8f;
   // Small image space distances for keypoint matches.
-  static constexpr int kSmallSearchDistance = 10;
+  int kSmallSearchDistance;
   // Large image space distances for keypoint matches.
   // Only used if small search was unsuccessful.
-  static constexpr int kLargeSearchDistance = 20;
+  int kLargeSearchDistance;
   // Number of iterations to match inferior matches.
   static constexpr size_t kMaxNumInferiorIterations = 3u;
 };

--- a/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
+++ b/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
@@ -1,11 +1,11 @@
 #include "aslam/matcher/gyro-two-frame-matcher.h"
 
 #include <aslam/common/statistics/statistics.h>
-#include <gflags/gflags.h>
+#include <glog/logging.h>
 
-DEFINE_int(gyro_matcher_small_search_distance_px, 10, 
+DEFINE_int32(gyro_matcher_small_search_distance_px, 10, 
     "Small image space distances for keypoint matches.");
-DEFINE_int(gyro_matcher_large_search_distance_px, 20, 
+DEFINE_int32(gyro_matcher_large_search_distance_px, 20, 
     "Large image space distances for keypoint matches."
     " Only used if small search was unsuccessful.");
 
@@ -29,8 +29,8 @@ GyroTwoFrameMatcher::GyroTwoFrameMatcher(
     matches_kp1_k_(matches_with_score_kp1_k),
     is_keypoint_kp1_matched_(kNumPointsKp1, false),
     iteration_processed_keypoints_kp1_(kNumPointsKp1, false),
-    kSmallSearchDistance_(FLAGS_gyro_small_search_distance_px), 
-    kLargeSearchDistance_(FLAGS_gyro_large_search_distance_px) {
+    kSmallSearchDistance(FLAGS_gyro_matcher_small_search_distance_px), 
+    kLargeSearchDistance(FLAGS_gyro_matcher_large_search_distance_px) {
   CHECK(frame_kp1.isValid());
   CHECK(frame_k.isValid());
   CHECK(frame_kp1.hasDescriptors());
@@ -143,8 +143,8 @@ void GyroTwoFrameMatcher::matchKeypoint(const int idx_k) {
   Eigen::Vector2d predicted_keypoint_position_kp1 =
       predicted_keypoint_positions_kp1_.block<2, 1>(0, idx_k);
   KeyPointIterator nearest_corners_begin, nearest_corners_end;
-  getKeypointIteratorsInWindow<kSmallSearchDistance>(
-      predicted_keypoint_position_kp1, &nearest_corners_begin, &nearest_corners_end);
+  getKeypointIteratorsInWindow(
+      predicted_keypoint_position_kp1, kSmallSearchDistance, &nearest_corners_begin, &nearest_corners_end);
 
   const int bound_left_nearest =
       predicted_keypoint_position_kp1(0) - kSmallSearchDistance;
@@ -192,8 +192,8 @@ void GyroTwoFrameMatcher::matchKeypoint(const int idx_k) {
         predicted_keypoint_position_kp1(0) + kLargeSearchDistance;
 
     KeyPointIterator near_corners_begin, near_corners_end;
-    getKeypointIteratorsInWindow<kLargeSearchDistance>(
-        predicted_keypoint_position_kp1, &near_corners_begin, &near_corners_end);
+    getKeypointIteratorsInWindow(
+        predicted_keypoint_position_kp1, kLargeSearchDistance, &near_corners_begin, &near_corners_end);
 
     for (KeyPointIterator it = near_corners_begin; it != near_corners_end; ++it) {
       if (iteration_processed_keypoints_kp1_[it->channel_index]) {

--- a/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
+++ b/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
@@ -3,8 +3,11 @@
 #include <aslam/common/statistics/statistics.h>
 #include <gflags/gflags.h>
 
-DEFINE_int(gyro_matcher_small_search_distance_px, 10, "Small image space distances for keypoint matches.");
-DEFINE_int(gyro_matcher_large_search_distance_px, 20, "Large image space distances for keypoint matches. Only used if small search was unsuccessful.");
+DEFINE_int(gyro_matcher_small_search_distance_px, 10, 
+    "Small image space distances for keypoint matches.");
+DEFINE_int(gyro_matcher_large_search_distance_px, 20, 
+    "Large image space distances for keypoint matches."
+    " Only used if small search was unsuccessful.");
 
 namespace aslam {
 

--- a/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
+++ b/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
@@ -29,8 +29,8 @@ GyroTwoFrameMatcher::GyroTwoFrameMatcher(
     matches_kp1_k_(matches_with_score_kp1_k),
     is_keypoint_kp1_matched_(kNumPointsKp1, false),
     iteration_processed_keypoints_kp1_(kNumPointsKp1, false),
-    kSmallSearchDistance(FLAGS_gyro_matcher_small_search_distance_px), 
-    kLargeSearchDistance(FLAGS_gyro_matcher_large_search_distance_px) {
+    small_search_distance_px_(FLAGS_gyro_matcher_small_search_distance_px), 
+    large_search_distance_px_(FLAGS_gyro_matcher_large_search_distance_px) {
   CHECK(frame_kp1.isValid());
   CHECK(frame_k.isValid());
   CHECK(frame_kp1.hasDescriptors());
@@ -144,12 +144,12 @@ void GyroTwoFrameMatcher::matchKeypoint(const int idx_k) {
       predicted_keypoint_positions_kp1_.block<2, 1>(0, idx_k);
   KeyPointIterator nearest_corners_begin, nearest_corners_end;
   getKeypointIteratorsInWindow(
-      predicted_keypoint_position_kp1, kSmallSearchDistance, &nearest_corners_begin, &nearest_corners_end);
+      predicted_keypoint_position_kp1, small_search_distance_px_, &nearest_corners_begin, &nearest_corners_end);
 
   const int bound_left_nearest =
-      predicted_keypoint_position_kp1(0) - kSmallSearchDistance;
+      predicted_keypoint_position_kp1(0) - small_search_distance_px_;
   const int bound_right_nearest =
-      predicted_keypoint_position_kp1(0) + kSmallSearchDistance;
+      predicted_keypoint_position_kp1(0) + small_search_distance_px_;
 
   MatchData current_match_data;
 
@@ -187,13 +187,13 @@ void GyroTwoFrameMatcher::matchKeypoint(const int idx_k) {
   // If no match in small window, increase window and search again.
   if (!found) {
     const int bound_left_near =
-        predicted_keypoint_position_kp1(0) - kLargeSearchDistance;
+        predicted_keypoint_position_kp1(0) - large_search_distance_px_;
     const int bound_right_near =
-        predicted_keypoint_position_kp1(0) + kLargeSearchDistance;
+        predicted_keypoint_position_kp1(0) + large_search_distance_px_;
 
     KeyPointIterator near_corners_begin, near_corners_end;
     getKeypointIteratorsInWindow(
-        predicted_keypoint_position_kp1, kLargeSearchDistance, &near_corners_begin, &near_corners_end);
+        predicted_keypoint_position_kp1, large_search_distance_px_, &near_corners_begin, &near_corners_end);
 
     for (KeyPointIterator it = near_corners_begin; it != near_corners_end; ++it) {
       if (iteration_processed_keypoints_kp1_[it->channel_index]) {

--- a/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
+++ b/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
@@ -4,9 +4,9 @@
 #include <glog/logging.h>
 
 DEFINE_int32(gyro_matcher_small_search_distance_px, 10, 
-    "Small image space distances for keypoint matches.");
+    "Small search rectangle size for keypoint matches.");
 DEFINE_int32(gyro_matcher_large_search_distance_px, 20, 
-    "Large image space distances for keypoint matches."
+    "Large search rectangle size for keypoint matches."
     " Only used if small search was unsuccessful.");
 
 namespace aslam {
@@ -50,6 +50,9 @@ GyroTwoFrameMatcher::GyroTwoFrameMatcher(
   CHECK_EQ(iteration_processed_keypoints_kp1_.size(), kNumPointsKp1);
   CHECK_EQ(is_keypoint_kp1_matched_.size(), kNumPointsKp1);
   CHECK_EQ(prediction_success_.size(), predicted_keypoint_positions_kp1_.cols());
+  CHECK_GT(small_search_distance_px_, 0);
+  CHECK_GT(large_search_distance_px_, 0);
+  CHECK_GE(large_search_distance_px_, small_search_distance_px_);
 
   descriptors_kp1_wrapped_.reserve(kNumPointsKp1);
   keypoints_kp1_sorted_by_y_.reserve(kNumPointsKp1);

--- a/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
+++ b/aslam_cv_matcher/src/gyro-two-frame-matcher.cc
@@ -1,6 +1,10 @@
 #include "aslam/matcher/gyro-two-frame-matcher.h"
 
 #include <aslam/common/statistics/statistics.h>
+#include <gflags/gflags.h>
+
+DEFINE_int(gyro_matcher_small_search_distance_px, 10, "Small image space distances for keypoint matches.");
+DEFINE_int(gyro_matcher_large_search_distance_px, 20, "Large image space distances for keypoint matches. Only used if small search was unsuccessful.");
 
 namespace aslam {
 
@@ -21,7 +25,9 @@ GyroTwoFrameMatcher::GyroTwoFrameMatcher(
     kImageHeight(image_height),
     matches_kp1_k_(matches_with_score_kp1_k),
     is_keypoint_kp1_matched_(kNumPointsKp1, false),
-    iteration_processed_keypoints_kp1_(kNumPointsKp1, false) {
+    iteration_processed_keypoints_kp1_(kNumPointsKp1, false),
+    kSmallSearchDistance_(FLAGS_gyro_small_search_distance_px), 
+    kLargeSearchDistance_(FLAGS_gyro_large_search_distance_px) {
   CHECK(frame_kp1.isValid());
   CHECK(frame_k.isValid());
   CHECK(frame_kp1.hasDescriptors());


### PR DESCRIPTION
Enable to set the search radius as a flag to support higher camera resolutions.

Associated flag is also [gyro_lk_window_size](https://github.com/ethz-asl/aslam_cv2/blob/960f0506050b24f2676a206b8656c9e3fc8618a9/aslam_cv_tracker/src/feature-tracker-gyro.cc#L30) for the LK tracker.