### PR TITLE
remove aslam_cv_build dependency

### DIFF
--- a/aslam_cv_frames/package.xml
+++ b/aslam_cv_frames/package.xml
@@ -8,7 +8,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
-  <buildtool_depend>aslam_cv_build</buildtool_depend>
 
   <depend>aslam_cv_cameras</depend>
   <depend>aslam_cv_common</depend>


### PR DESCRIPTION
Pretty sure this is not used anymore. True?