### PR TITLE
Add test for multithreaded statistics.

### DIFF
--- a/aslam_cv_common/CMakeLists.txt
+++ b/aslam_cv_common/CMakeLists.txt
@@ -41,6 +41,9 @@ target_link_libraries(test_eigen-yaml-serialization ${PROJECT_NAME})
 catkin_add_gtest(test_hash_id test/test-hash-id.cc)
 target_link_libraries(test_hash_id ${PROJECT_NAME})
 
+catkin_add_gtest(test_statistics test/test-statistics.cc)
+target_link_libraries(test_statistics ${PROJECT_NAME})
+
 catkin_add_gtest(test_stl_helpers test/test-stl-helpers.cc)
 target_link_libraries(test_stl_helpers ${PROJECT_NAME})
 

--- a/aslam_cv_common/test/test-statistics.cc
+++ b/aslam_cv_common/test/test-statistics.cc
@@ -1,0 +1,37 @@
+#include <thread>
+#include <vector>
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <aslam/common/entrypoint.h>
+#include <aslam/common/statistics/statistics.h>
+
+TEST(StatisticsCollector, Multithread_Adds) {
+  const std::string kStatisticsName("value_name");
+  constexpr size_t kNumThreads = 100u;
+  constexpr size_t kNumValues = 10000u;
+
+  auto AddStatisticValues = [&]() {
+    for (size_t i = 0u; i < kNumValues; ++i) {
+      statistics::StatsCollectorImpl collector(kStatisticsName);
+      collector.IncrementOne();
+    }
+  };
+
+  std::vector<std::thread> threads;
+  for (size_t thread_idx = 0u; thread_idx < kNumThreads; ++thread_idx) {
+    threads.push_back(std::thread(AddStatisticValues));
+  }
+  for (std::thread& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_EQ(statistics::Statistics::GetNumSamples(kStatisticsName),
+            kNumThreads * kNumValues);
+  EXPECT_EQ(statistics::Statistics::GetMean(kStatisticsName), 1u);
+  EXPECT_EQ(statistics::Statistics::GetMax(kStatisticsName),  1u);
+  EXPECT_EQ(statistics::Statistics::GetMin(kStatisticsName),  1u);
+}
+
+ASLAM_UNITTEST_ENTRYPOINT


### PR DESCRIPTION
The multi-threaded access to the StatisticsCollector seems to be super slow, ~11 seconds for 10000 values. Maybe we should re-think the concept.