### PR TITLE
more tolerance in reading yaml

### DIFF
--- a/aslam_cv_cameras/src/ncamera-yaml-serialization.cc
+++ b/aslam_cv_cameras/src/ncamera-yaml-serialization.cc
@@ -73,9 +73,10 @@ bool convert<std::shared_ptr<aslam::NCamera> >::decode(const Node& node,
         return true;
       }
       // This call will fail hard if the matrix is not a rotation matrix.
-      aslam::Quaternion q_B_C = aslam::Quaternion(
+      const aslam::Quaternion q_B_C =
+          aslam::Quaternion::fromApproximateRotationMatrix(
           static_cast<Eigen::Matrix3d>(T_B_C_raw.block<3,3>(0,0)));
-      aslam::Transformation T_B_C(q_B_C, T_B_C_raw.block<3,1>(0,3));
+      const aslam::Transformation T_B_C(q_B_C, T_B_C_raw.block<3,1>(0,3));
 
       // Fill in the data in the ncamera.
       cameras.push_back(camera);


### PR DESCRIPTION
The underlying problem is the following:
Minkindr is machine-precision strict when it comes to the construction of rotation matrices.
Reading/writing rotation matrices to/from file (e.g., to a YAML file) is usually less precise, because much fewer number of digits are used compared to floating point machine precision. 
This occasionally led to check fails when reading in YAML files with in principle correct rotation matrices.

Note that `fromApproximateRotationMatrix()` still checks that the given matrix is a valid rotation matrix, but it's not as numerically strict as the default constructor.