### PR TITLE
3D Lidar range image camera model

### DIFF
--- a/aslam_cv_cameras/CMakeLists.txt
+++ b/aslam_cv_cameras/CMakeLists.txt
@@ -10,6 +10,7 @@ catkin_simple(ALL_DEPS_REQUIRED)
 set(SOURCES
   src/camera-factory.cc
   src/camera-pinhole.cc
+  src/camera-3d-lidar.cc
   src/camera-unified-projection.cc
   src/camera.cc
   src/distortion-equidistant.cc
@@ -27,8 +28,11 @@ add_doxygen(NOT_AUTOMATIC)
 ##########
 # GTESTS #
 ##########
-#catkin_add_gtest(test_cameras test/test-cameras.cc)
-#target_link_libraries(test_cameras ${PROJECT_NAME})
+catkin_add_gtest(test_cameras test/test-cameras.cc)
+target_link_libraries(test_cameras ${PROJECT_NAME})
+
+catkin_add_gtest(test_camera_lidar_3d test/test-camera-lidar-3d.cc)
+target_link_libraries(test_camera_lidar_3d ${PROJECT_NAME})
 
 catkin_add_gtest(test_distortions test/test-distortions.cc)
 target_link_libraries(test_distortions ${PROJECT_NAME})

--- a/aslam_cv_cameras/CMakeLists.txt
+++ b/aslam_cv_cameras/CMakeLists.txt
@@ -8,9 +8,9 @@ catkin_simple(ALL_DEPS_REQUIRED)
 # LIBRARIES #
 #############
 set(SOURCES
+  src/camera-3d-lidar.cc
   src/camera-factory.cc
   src/camera-pinhole.cc
-  src/camera-3d-lidar.cc
   src/camera-unified-projection.cc
   src/camera.cc
   src/distortion-equidistant.cc
@@ -31,8 +31,8 @@ add_doxygen(NOT_AUTOMATIC)
 catkin_add_gtest(test_cameras test/test-cameras.cc)
 target_link_libraries(test_cameras ${PROJECT_NAME})
 
-catkin_add_gtest(test_camera_lidar_3d test/test-camera-lidar-3d.cc)
-target_link_libraries(test_camera_lidar_3d ${PROJECT_NAME})
+catkin_add_gtest(test_camera_3d_lidar test/test-camera-3d-lidar.cc)
+target_link_libraries(test_camera_3d_lidar ${PROJECT_NAME})
 
 catkin_add_gtest(test_distortions test/test-distortions.cc)
 target_link_libraries(test_distortions ${PROJECT_NAME})

--- a/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar-inl.h
+++ b/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar-inl.h
@@ -8,7 +8,7 @@ namespace aslam {
 template <
     typename ScalarType, typename DistortionType, typename MIntrinsics,
     typename MDistortion>
-const ProjectionResult CameraLidar3D::project3Functional(
+const ProjectionResult Camera3DLidar::project3Functional(
     const Eigen::Matrix<ScalarType, 3, 1>& point_3d,
     const Eigen::MatrixBase<MIntrinsics>& intrinsics_external,
     const Eigen::MatrixBase<MDistortion>& distortion_coefficients_external,
@@ -17,54 +17,49 @@ const ProjectionResult CameraLidar3D::project3Functional(
   CHECK_EQ(intrinsics_external.size(), kNumOfParams)
       << "intrinsics: invalid size!";
 
-  const ScalarType x_z_scalar_inv =
-      std::sqrt(point_3d.x() * point_3d.x() + point_3d.z() * point_3d.z());
-  CHECK_GT(x_z_scalar_inv, 1e-6);
+  if (point_3d.norm() < 1e-6) {
+    (*out_keypoint)[0] = 0;
+    (*out_keypoint)[1] = 0;
+    return ProjectionResult(ProjectionResult::Status::PROJECTION_INVALID);
+  }
 
-  const Eigen::Matrix<ScalarType, 3, 1> bearing_vec_on_cylinder =
-      point_3d / x_z_scalar_inv;
+  const Eigen::Matrix<ScalarType, 3, 1> bearing_vector = point_3d.normalized();
 
-  const ScalarType x_z_norm = std::sqrt(
-      bearing_vec_on_cylinder.x() * bearing_vec_on_cylinder.x() +
-      bearing_vec_on_cylinder.z() * bearing_vec_on_cylinder.z());
-  CHECK_LT(std::abs(x_z_norm - 1.0), 1e-6);
-
-  (*out_keypoint)[0] =
-      (std::atan2(bearing_vec_on_cylinder.x(), bearing_vec_on_cylinder.z()) +
-       horizontalCenter()) /
-      horizontalResolution();
+  (*out_keypoint)[0] = (std::atan2(bearing_vector.x(), bearing_vector.z()) +
+                        horizontalCenter()) /
+                       horizontalResolution();
 
   if ((*out_keypoint)[0] < 0.0) {
     (*out_keypoint)[0] = imageWidth() + (*out_keypoint)[0];
   }
 
   (*out_keypoint)[1] =
-      ((std::atan(bearing_vec_on_cylinder.y()) + verticalCenter()) /
+      ((std::asin(bearing_vector.y()) + verticalCenter()) /
        verticalResolution());
 
   return evaluateProjectionResult(*out_keypoint, point_3d);
 }
 
 template <typename DerivedKeyPoint, typename DerivedPoint3d>
-inline const ProjectionResult CameraLidar3D::evaluateProjectionResult(
+inline const ProjectionResult Camera3DLidar::evaluateProjectionResult(
     const Eigen::MatrixBase<DerivedKeyPoint>& keypoint,
     const Eigen::MatrixBase<DerivedPoint3d>& point_3d) const {
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(DerivedKeyPoint, 2, 1);
   EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(DerivedPoint3d, 3, 1);
 
   Eigen::Matrix<typename DerivedKeyPoint::Scalar, 2, 1> kp = keypoint;
-  const bool visibility = isKeypointVisible(kp);
-
+  const bool is_visible = isKeypointVisible(kp);
   const double squaredNorm = point_3d.squaredNorm();
   const bool is_outside_min_depth = squaredNorm > kSquaredMinimumDepth;
 
-  if (visibility && is_outside_min_depth)
+  if (is_visible && is_outside_min_depth) {
     return ProjectionResult(ProjectionResult::Status::KEYPOINT_VISIBLE);
-  else if (!visibility && is_outside_min_depth)
+  } else if (!is_visible && is_outside_min_depth) {
     return ProjectionResult(
         ProjectionResult::Status::KEYPOINT_OUTSIDE_IMAGE_BOX);
-  else
+  } else {
     return ProjectionResult(ProjectionResult::Status::PROJECTION_INVALID);
+  }
 }
 
 }  // namespace aslam

--- a/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar-inl.h
+++ b/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar-inl.h
@@ -1,0 +1,71 @@
+#ifndef ASLAM_CAMERAS_CAMERA_3D_LIDAR_INL_H_
+#define ASLAM_CAMERAS_CAMERA_3D_LIDAR_INL_H_
+
+#include <memory>
+
+namespace aslam {
+
+template <
+    typename ScalarType, typename DistortionType, typename MIntrinsics,
+    typename MDistortion>
+const ProjectionResult CameraLidar3D::project3Functional(
+    const Eigen::Matrix<ScalarType, 3, 1>& point_3d,
+    const Eigen::MatrixBase<MIntrinsics>& intrinsics_external,
+    const Eigen::MatrixBase<MDistortion>& distortion_coefficients_external,
+    Eigen::Matrix<ScalarType, 2, 1>* out_keypoint) const {
+  CHECK_NOTNULL(out_keypoint);
+  CHECK_EQ(intrinsics_external.size(), kNumOfParams)
+      << "intrinsics: invalid size!";
+
+  const ScalarType x_z_scalar_inv =
+      std::sqrt(point_3d.x() * point_3d.x() + point_3d.z() * point_3d.z());
+  CHECK_GT(x_z_scalar_inv, 1e-6);
+
+  const Eigen::Matrix<ScalarType, 3, 1> bearing_vec_on_cylinder =
+      point_3d / x_z_scalar_inv;
+
+  const ScalarType x_z_norm = std::sqrt(
+      bearing_vec_on_cylinder.x() * bearing_vec_on_cylinder.x() +
+      bearing_vec_on_cylinder.z() * bearing_vec_on_cylinder.z());
+  CHECK_LT(std::abs(x_z_norm - 1.0), 1e-6);
+
+  (*out_keypoint)[0] =
+      (std::atan2(bearing_vec_on_cylinder.x(), bearing_vec_on_cylinder.z()) +
+       horizontalCenter()) /
+      horizontalResolution();
+
+  if ((*out_keypoint)[0] < 0.0) {
+    (*out_keypoint)[0] = imageWidth() + (*out_keypoint)[0];
+  }
+
+  (*out_keypoint)[1] =
+      ((std::atan(bearing_vec_on_cylinder.y()) + verticalCenter()) /
+       verticalResolution());
+
+  return evaluateProjectionResult(*out_keypoint, point_3d);
+}
+
+template <typename DerivedKeyPoint, typename DerivedPoint3d>
+inline const ProjectionResult CameraLidar3D::evaluateProjectionResult(
+    const Eigen::MatrixBase<DerivedKeyPoint>& keypoint,
+    const Eigen::MatrixBase<DerivedPoint3d>& point_3d) const {
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(DerivedKeyPoint, 2, 1);
+  EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(DerivedPoint3d, 3, 1);
+
+  Eigen::Matrix<typename DerivedKeyPoint::Scalar, 2, 1> kp = keypoint;
+  const bool visibility = isKeypointVisible(kp);
+
+  const double squaredNorm = point_3d.squaredNorm();
+  const bool is_outside_min_depth = squaredNorm > kSquaredMinimumDepth;
+
+  if (visibility && is_outside_min_depth)
+    return ProjectionResult(ProjectionResult::Status::KEYPOINT_VISIBLE);
+  else if (!visibility && is_outside_min_depth)
+    return ProjectionResult(
+        ProjectionResult::Status::KEYPOINT_OUTSIDE_IMAGE_BOX);
+  else
+    return ProjectionResult(ProjectionResult::Status::PROJECTION_INVALID);
+}
+
+}  // namespace aslam
+#endif  // ASLAM_CAMERAS_CAMERA_3D_LIDAR_INL_H_

--- a/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar.h
+++ b/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar.h
@@ -13,15 +13,15 @@ namespace aslam {
 class MappedUndistorter;
 class NCamera;
 
-/// \class CameraLidar3D
+/// \class Camera3DLidar
 /// \brief An implementation of a projection model for a 360 degree 3D lidar.
-class CameraLidar3D : public aslam::Cloneable<Camera, CameraLidar3D> {
+class Camera3DLidar : public aslam::Cloneable<Camera, Camera3DLidar> {
   friend class NCamera;
 
   enum { kNumOfParams = 4 };
 
  public:
-  ASLAM_POINTER_TYPEDEFS(CameraLidar3D);
+  ASLAM_POINTER_TYPEDEFS(Camera3DLidar);
 
   enum { CLASS_SERIALIZATION_VERSION = 1 };
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -39,27 +39,27 @@ class CameraLidar3D : public aslam::Cloneable<Camera, CameraLidar3D> {
 
  public:
   /// \brief Empty constructor for serialization interface.
-  CameraLidar3D();
+  Camera3DLidar();
 
   /// Copy constructor for clone operation.
-  CameraLidar3D(const CameraLidar3D& other) = default;
-  void operator=(const CameraLidar3D&) = delete;
+  Camera3DLidar(const Camera3DLidar& other) = default;
+  void operator=(const Camera3DLidar&) = delete;
 
  public:
-  /// \brief Construct a CameraLidar3D
+  /// \brief Construct a Camera3DLidar
   /// @param[in] intrinsics  (Horizontal-, vertical- resolution in radians,
   /// frequency in Hz).
   /// @param[in] image_width  Image width in pixels.
   /// @param[in] image_height Image height in pixels.
-  CameraLidar3D(
+  Camera3DLidar(
       const Eigen::VectorXd& intrinsics, uint32_t image_width,
       uint32_t image_height);
 
-  virtual ~CameraLidar3D(){};
+  virtual ~Camera3DLidar(){};
 
   /// \brief Convenience function to print the state using streams.
   friend std::ostream& operator<<(
-      std::ostream& out, const CameraLidar3D& camera);
+      std::ostream& out, const Camera3DLidar& camera);
 
   /// @}
 
@@ -224,21 +224,23 @@ class CameraLidar3D : public aslam::Cloneable<Camera, CameraLidar3D> {
 
   /// \brief Create a test camera object for unit testing.
   template <typename DistortionType = NullDistortion>
-  static CameraLidar3D::Ptr createTestCamera() {
-    return CameraLidar3D::Ptr(
+  static Camera3DLidar::Ptr createTestCamera() {
+    return Camera3DLidar::Ptr(
         std::move(createTestCameraUnique<DistortionType>()));
   }
 
-  /// \brief Create a test camera object for unit testing. Simulates OS-1 lidar.
+  /// \brief Create a test camera object for unit testing.
+  // Simulates OS-1 64-beam lidar.
   template <typename DistortionType = NullDistortion>
-  static CameraLidar3D::UniquePtr createTestCameraUnique() {
+  static Camera3DLidar::UniquePtr createTestCameraUnique() {
     Eigen::VectorXd intrinsics(4, 1);
     intrinsics[Parameters::kHorizontalResolutionRad] = 2. * M_PI / 1024.;
-    intrinsics[Parameters::kVerticalResolutionRad] = 0.558505361 / 64.;
-    intrinsics[Parameters::kVerticalCenterRad] = 0.558505361 / 2.;
-    intrinsics[Parameters::kHorizontalCenterRad] = 0.0;
+    intrinsics[Parameters::kVerticalResolutionRad] =
+        0.009203703;  // 0.527333333 deg
+    intrinsics[Parameters::kVerticalCenterRad] = 0.289916642;  // 16.611 deg
+    intrinsics[Parameters::kHorizontalCenterRad] = 0;
 
-    CameraLidar3D::UniquePtr camera = aligned_unique<CameraLidar3D>(
+    Camera3DLidar::UniquePtr camera = aligned_unique<Camera3DLidar>(
         intrinsics, 1024u /*width*/, 64u /*height*/);
     CameraId id;
     generateId(&id);

--- a/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar.h
+++ b/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar.h
@@ -1,0 +1,262 @@
+#ifndef ASLAM_CAMERAS_CAMERA_3D_LIDAR_H_
+#define ASLAM_CAMERAS_CAMERA_3D_LIDAR_H_
+
+#include <aslam/cameras/camera.h>
+#include <aslam/cameras/distortion.h>
+#include <aslam/common/crtp-clone.h>
+#include <aslam/common/macros.h>
+#include <aslam/common/types.h>
+
+namespace aslam {
+
+// Forward declarations.
+class MappedUndistorter;
+class NCamera;
+
+/// \class CameraLidar3D
+/// \brief An implementation of a projection model for a 360 degree 3D lidar.
+class CameraLidar3D : public aslam::Cloneable<Camera, CameraLidar3D> {
+  friend class NCamera;
+
+  enum { kNumOfParams = 4 };
+
+ public:
+  ASLAM_POINTER_TYPEDEFS(CameraLidar3D);
+
+  enum { CLASS_SERIALIZATION_VERSION = 1 };
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  enum Parameters {
+    kHorizontalResolutionRad = 0,
+    kVerticalResolutionRad = 1,
+    kVerticalCenterRad = 2,
+    kHorizontalCenterRad = 3
+  };
+
+  //////////////////////////////////////////////////////////////
+  /// \name Constructors/destructors and operators
+  /// @{
+
+ public:
+  /// \brief Empty constructor for serialization interface.
+  CameraLidar3D();
+
+  /// Copy constructor for clone operation.
+  CameraLidar3D(const CameraLidar3D& other) = default;
+  void operator=(const CameraLidar3D&) = delete;
+
+ public:
+  /// \brief Construct a CameraLidar3D
+  /// @param[in] intrinsics  (Horizontal-, vertical- resolution in radians,
+  /// frequency in Hz).
+  /// @param[in] image_width  Image width in pixels.
+  /// @param[in] image_height Image height in pixels.
+  CameraLidar3D(
+      const Eigen::VectorXd& intrinsics, uint32_t image_width,
+      uint32_t image_height);
+
+  virtual ~CameraLidar3D(){};
+
+  /// \brief Convenience function to print the state using streams.
+  friend std::ostream& operator<<(
+      std::ostream& out, const CameraLidar3D& camera);
+
+  /// @}
+
+  //////////////////////////////////////////////////////////////
+  /// \name Methods to project and back-project euclidean points
+  /// @{
+
+  /// \brief Compute the 3d bearing vector in euclidean coordinates given a
+  /// keypoint in
+  ///        image coordinates. Uses the projection (& distortion) models.
+  ///        The result might be in normalized image plane for some camera
+  ///        implementations but not for the general case.
+  /// @param[in]  keypoint     Keypoint in image coordinates.
+  /// @param[out] out_point_3d Bearing vector in euclidean coordinates
+  virtual bool backProject3(
+      const Eigen::Ref<const Eigen::Vector2d>& keypoint,
+      Eigen::Vector3d* out_point_3d) const;
+
+  /// \brief Checks the success of a projection operation and returns the result
+  /// in a
+  ///        ProjectionResult object.
+  /// @param[in] keypoint Keypoint in image coordinates.
+  /// @param[in] point_3d Projected point in euclidean.
+  /// @return The ProjectionResult object contains details about the success of
+  /// the projection.
+  template <typename DerivedKeyPoint, typename DerivedPoint3d>
+  inline const ProjectionResult evaluateProjectionResult(
+      const Eigen::MatrixBase<DerivedKeyPoint>& keypoint,
+      const Eigen::MatrixBase<DerivedPoint3d>& point_3d) const;
+
+  /// @}
+
+  //////////////////////////////////////////////////////////////
+  /// \name Functional methods to project and back-project points
+  /// @{
+
+  // Get the overloaded non-virtual project3Functional(..) from base into scope.
+  using Camera::project3Functional;
+
+  /// \brief Template version of project3Functional.
+  template <
+      typename ScalarType, typename DistortionType, typename MIntrinsics,
+      typename MDistortion>
+  const ProjectionResult project3Functional(
+      const Eigen::Matrix<ScalarType, 3, 1>& point_3d,
+      const Eigen::MatrixBase<MIntrinsics>& intrinsics_external,
+      const Eigen::MatrixBase<MDistortion>& distortion_coefficients_external,
+      Eigen::Matrix<ScalarType, 2, 1>* out_keypoint) const;
+
+  /// \brief This function projects a point into the image using the intrinsic
+  /// parameters
+  ///        that are passed in as arguments. If any of the Jacobians are
+  ///        nonnull, they should be filled in with the Jacobian with respect to
+  ///        small changes in the argument.
+  /// @param[in]  point_3d                The point in euclidean coordinates.
+  /// @param[in]  intrinsics_external     External intrinsic parameter vector.
+  ///                                     NOTE: If nullptr, use internal
+  ///                                     distortion parameters.
+  /// @param[in]  distortion_coefficients_external External distortion parameter
+  /// vector.
+  ///                                     Parameter is ignored is no distortion
+  ///                                     is active. NOTE: If nullptr, use
+  ///                                     internal distortion parameters.
+  ///                                     NOTE: THIS IS NOT USABLE FOR THIS
+  ///                                     CAMERA!
+  /// @param[out] out_keypoint            The keypoint in image coordinates.
+  ///                                     NOTE: THIS IS NOT USABLE FOR THIS
+  ///                                     CAMERA!
+  /// @param[out] out_jacobian_point      The Jacobian wrt. to changes in the
+  /// euclidean point.
+  ///                                       nullptr: calculation is skipped.
+  ///                                     NOTE: THIS IS NOT USABLE FOR THIS
+  ///                                     CAMERA!
+  /// @param[out] out_jacobian_intrinsics The Jacobian wrt. to changes in the
+  /// intrinsics.
+  ///                                       nullptr: calculation is skipped.
+  ///                                     NOTE: THIS IS NOT USABLE FOR THIS
+  ///                                     CAMERA!
+  /// @param[out] out_jacobian_distortion The Jacobian wrt. to changes in the
+  /// distortion parameters.
+  ///                                       nullptr: calculation is skipped.
+  ///                                     NOTE: THIS IS NOT USABLE FOR THIS
+  ///                                     CAMERA!
+  /// @return Contains information about the success of the projection. Check
+  ///         \ref ProjectionResult for more information.
+  virtual const ProjectionResult project3Functional(
+      const Eigen::Ref<const Eigen::Vector3d>& point_3d,
+      const Eigen::VectorXd* intrinsics_external,
+      const Eigen::VectorXd* distortion_coefficients_external,
+      Eigen::Vector2d* out_keypoint,
+      Eigen::Matrix<double, 2, 3>* out_jacobian_point,
+      Eigen::Matrix<double, 2, Eigen::Dynamic>* out_jacobian_intrinsics,
+      Eigen::Matrix<double, 2, Eigen::Dynamic>* out_jacobian_distortion) const;
+
+  /// @}
+
+  //////////////////////////////////////////////////////////////
+  /// \name Methods to support unit testing.
+  /// @{
+
+  /// \brief Creates a random valid keypoint..
+  virtual Eigen::Vector2d createRandomKeypoint() const;
+
+  /// \brief Creates a random visible point. Negative depth means random between
+  ///        0 and 100 meters.
+  virtual Eigen::Vector3d createRandomVisiblePoint(double depth) const;
+
+  /// \brief Get a set of border rays
+  void getBorderRays(Eigen::MatrixXd& rays) const;
+
+  /// @}
+
+ public:
+  //////////////////////////////////////////////////////////////
+  /// \name Methods to access intrinsics.
+  /// @{
+
+  /// \brief The vertical resolution of the lidar in radians
+  double verticalResolution() const {
+    return intrinsics_[Parameters::kVerticalResolutionRad];
+  };
+  /// \brief The horizontal resolution of the lidar in radians.
+  double horizontalResolution() const {
+    return intrinsics_[Parameters::kHorizontalResolutionRad];
+  };
+  /// \brief The horizontal center of the image.
+  double horizontalCenter() const {
+    return intrinsics_[Parameters::kHorizontalCenterRad];
+  };
+  /// \brief The vertical center of the image.
+  double verticalCenter() const {
+    return intrinsics_[Parameters::kVerticalCenterRad];
+  };
+
+  /// \brief Returns the number of intrinsic parameters used in this camera
+  /// model.
+  inline static constexpr int parameterCount() {
+    return kNumOfParams;
+  }
+
+  /// \brief Returns the number of intrinsic parameters used in this camera
+  /// model.
+  inline virtual int getParameterSize() const {
+    return kNumOfParams;
+  }
+
+  /// Static function that checks whether the given intrinsic parameters are
+  /// valid for this model.
+  static bool areParametersValid(const Eigen::VectorXd& parameters);
+
+  /// Function to check whether the given intrinsic parameters are valid for
+  /// this model.
+  virtual bool intrinsicsValid(const Eigen::VectorXd& intrinsics) const;
+
+  /// Print the internal parameters of the camera in a human-readable form
+  /// Print to the ostream that is passed in. The text is extra
+  /// text used by the calling function to distinguish cameras
+  virtual void printParameters(
+      std::ostream& out, const std::string& text) const;
+
+  /// @}
+
+  /// \brief Create a test camera object for unit testing.
+  template <typename DistortionType = NullDistortion>
+  static CameraLidar3D::Ptr createTestCamera() {
+    return CameraLidar3D::Ptr(
+        std::move(createTestCameraUnique<DistortionType>()));
+  }
+
+  /// \brief Create a test camera object for unit testing. Simulates OS-1 lidar.
+  template <typename DistortionType = NullDistortion>
+  static CameraLidar3D::UniquePtr createTestCameraUnique() {
+    Eigen::VectorXd intrinsics(4, 1);
+    intrinsics[Parameters::kHorizontalResolutionRad] = 2. * M_PI / 1024.;
+    intrinsics[Parameters::kVerticalResolutionRad] = 0.558505361 / 64.;
+    intrinsics[Parameters::kVerticalCenterRad] = 0.558505361 / 2.;
+    intrinsics[Parameters::kHorizontalCenterRad] = 0.0;
+
+    CameraLidar3D::UniquePtr camera = aligned_unique<CameraLidar3D>(
+        intrinsics, 1024u /*width*/, 64u /*height*/);
+    CameraId id;
+    generateId(&id);
+    camera->setId(id);
+    return std::move(camera);
+  }
+
+ private:
+  /// \brief Minimal depth for a valid projection.
+  static const double kSquaredMinimumDepth;
+
+  bool isValidImpl() const override;
+  void setRandomImpl() override;
+  bool isEqualImpl(const Sensor& other, const bool verbose) const override;
+};
+
+}  // namespace aslam
+
+#include "aslam/cameras/camera-3d-lidar-inl.h"
+
+#endif  // ASLAM_CAMERAS_CAMERA_3D_LIDAR_H_

--- a/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar.h
+++ b/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar.h
@@ -52,8 +52,8 @@ class Camera3DLidar : public aslam::Cloneable<Camera, Camera3DLidar> {
   /// @param[in] image_width  Image width in pixels.
   /// @param[in] image_height Image height in pixels.
   Camera3DLidar(
-      const Eigen::VectorXd& intrinsics, uint32_t image_width,
-      uint32_t image_height);
+      const Eigen::VectorXd& intrinsics, const uint32_t image_width,
+      const uint32_t image_height);
 
   virtual ~Camera3DLidar(){};
 

--- a/aslam_cv_cameras/include/aslam/cameras/camera.h
+++ b/aslam_cv_cameras/include/aslam/cameras/camera.h
@@ -103,7 +103,8 @@ class Camera : public Sensor {
 
   enum class Type {
     kPinhole = 0,
-    kUnifiedProjection = 1
+    kUnifiedProjection = 1,
+    kLidar3D = 2,
   };
 
   //////////////////////////////////////////////////////////////
@@ -175,7 +176,7 @@ class Camera : public Sensor {
   void operator=(const Camera&) = delete;
 
   /// \brief Compare only the parameters of Camera to the ones of another Camera
-  bool isEqualCameraImpl(const Camera& other) const;
+  bool isEqualCameraImpl(const Camera& other, const bool verbose = false) const;
 
   /// @}
 

--- a/aslam_cv_cameras/src/camera-3d-lidar.cc
+++ b/aslam_cv_cameras/src/camera-3d-lidar.cc
@@ -18,8 +18,8 @@ Camera3DLidar::Camera3DLidar()
     : Base(Eigen::Vector3d::Zero(), 0, 0, Camera::Type::kLidar3D) {}
 
 Camera3DLidar::Camera3DLidar(
-    const Eigen::VectorXd& intrinsics, uint32_t image_width,
-    uint32_t image_height)
+    const Eigen::VectorXd& intrinsics, const uint32_t image_width,
+    const uint32_t image_height)
     : Base(intrinsics, image_width, image_height, Camera::Type::kLidar3D) {
   CHECK(intrinsicsValid(intrinsics));
 }
@@ -78,7 +78,7 @@ Eigen::Vector2d Camera3DLidar::createRandomKeypoint() const {
   out.setRandom();
   // Unit tests often fail when the point is near the border. Keep the point
   // away from the border.
-  double border = std::min(imageWidth(), imageHeight()) * 0.1;
+  const double border = std::min(imageWidth(), imageHeight()) * 0.1;
 
   out(0) = border + std::abs(out(0)) * (imageWidth() - border * 2.0);
   out(1) = border + std::abs(out(1)) * (imageHeight() - border * 2.0);

--- a/aslam_cv_cameras/src/camera-3d-lidar.cc
+++ b/aslam_cv_cameras/src/camera-3d-lidar.cc
@@ -1,0 +1,188 @@
+#include "aslam/cameras/camera-3d-lidar.h"
+
+#include <memory>
+#include <utility>
+
+#include <aslam/cameras/camera-factory.h>
+#include <aslam/common/types.h>
+
+#include "aslam/cameras/random-camera-generator.h"
+
+namespace aslam {
+std::ostream& operator<<(std::ostream& out, const CameraLidar3D& camera) {
+  camera.printParameters(out, std::string(""));
+  return out;
+}
+
+CameraLidar3D::CameraLidar3D()
+    : Base(Eigen::Vector3d::Zero(), 0, 0, Camera::Type::kLidar3D) {}
+
+CameraLidar3D::CameraLidar3D(
+    const Eigen::VectorXd& intrinsics, uint32_t image_width,
+    uint32_t image_height)
+    : Base(intrinsics, image_width, image_height, Camera::Type::kLidar3D) {
+  CHECK(intrinsicsValid(intrinsics));
+}
+
+bool CameraLidar3D::backProject3(
+    const Eigen::Ref<const Eigen::Vector2d>& keypoint,
+    Eigen::Vector3d* out_point_3d) const {
+  CHECK_NOTNULL(out_point_3d);
+
+  Eigen::Vector2d kp = keypoint;
+  kp[0] = kp[0] * horizontalResolution() - horizontalCenter();
+  kp[1] = (kp[1] * verticalResolution()) - verticalCenter();
+  (*out_point_3d)[0] = std::sin(kp[0]);
+  (*out_point_3d)[1] = std::tan(kp[1]);
+  (*out_point_3d)[2] = std::cos(kp[0]);
+
+  // Always valid for the pinhole model.
+  return true;
+}
+
+const ProjectionResult CameraLidar3D::project3Functional(
+    const Eigen::Ref<const Eigen::Vector3d>& point_3d,
+    const Eigen::VectorXd* intrinsics_external,
+    const Eigen::VectorXd* distortion_coefficients_external,
+    Eigen::Vector2d* out_keypoint,
+    Eigen::Matrix<double, 2, 3>* out_jacobian_point,
+    Eigen::Matrix<double, 2, Eigen::Dynamic>* out_jacobian_intrinsics,
+    Eigen::Matrix<double, 2, Eigen::Dynamic>* out_jacobian_distortion) const {
+  CHECK_NOTNULL(out_keypoint);
+
+  CHECK(distortion_coefficients_external == nullptr)
+      << "External distortion is not implemented!";
+  CHECK(out_jacobian_point == nullptr)
+      << "Jacobians are currently not implemented!";
+  CHECK(out_jacobian_intrinsics == nullptr)
+      << "Jacobians are currently not implemented!";
+  CHECK(out_jacobian_distortion == nullptr)
+      << "Jacobians are currently not implemented!";
+
+  // Determine the parameter source. (if nullptr, use internal)
+  const Eigen::VectorXd* intrinsics;
+  if (!intrinsics_external)
+    intrinsics = &getParameters();
+  else
+    intrinsics = intrinsics_external;
+  CHECK_EQ(intrinsics->size(), kNumOfParams) << "intrinsics: invalid size!";
+
+  // This camera does not have distortion, so we do not use this.
+  const Eigen::VectorXd dummy_distortion_coefficients;
+
+  return project3Functional<double, NullDistortion>(
+      point_3d, *intrinsics, dummy_distortion_coefficients, out_keypoint);
+}
+
+Eigen::Vector2d CameraLidar3D::createRandomKeypoint() const {
+  Eigen::Vector2d out;
+  out.setRandom();
+  // Unit tests often fail when the point is near the border. Keep the point
+  // away from the border.
+  double border = std::min(imageWidth(), imageHeight()) * 0.1;
+
+  out(0) = border + std::abs(out(0)) * (imageWidth() - border * 2.0);
+  out(1) = border + std::abs(out(1)) * (imageHeight() - border * 2.0);
+
+  return out;
+}
+
+Eigen::Vector3d CameraLidar3D::createRandomVisiblePoint(double depth) const {
+  CHECK_GT(depth, 0.0) << "Depth needs to be positive!";
+  Eigen::Vector3d point_3d;
+
+  Eigen::Vector2d y = createRandomKeypoint();
+  backProject3(y, &point_3d);
+  point_3d /= point_3d.norm();
+
+  // Muck with the depth. This doesn't change the pointing direction.
+  return point_3d * depth;
+}
+
+void CameraLidar3D::getBorderRays(Eigen::MatrixXd& rays) const {
+  rays.resize(4, 8);
+  Eigen::Vector4d ray;
+  backProject4(Eigen::Vector2d(0.0, 0.0), &ray);
+  rays.col(0) = ray;
+  backProject4(Eigen::Vector2d(0.0, imageHeight() * 0.5), &ray);
+  rays.col(1) = ray;
+  backProject4(Eigen::Vector2d(0.0, imageHeight() - 1.0), &ray);
+  rays.col(2) = ray;
+  backProject4(Eigen::Vector2d(imageWidth() - 1.0, 0.0), &ray);
+  rays.col(3) = ray;
+  backProject4(Eigen::Vector2d(imageWidth() - 1.0, imageHeight() * 0.5), &ray);
+  rays.col(4) = ray;
+  backProject4(Eigen::Vector2d(imageWidth() - 1.0, imageHeight() - 1.0), &ray);
+  rays.col(5) = ray;
+  backProject4(Eigen::Vector2d(imageWidth() * 0.5, 0.0), &ray);
+  rays.col(6) = ray;
+  backProject4(Eigen::Vector2d(imageWidth() * 0.5, imageHeight() - 1.0), &ray);
+  rays.col(7) = ray;
+}
+
+bool CameraLidar3D::areParametersValid(const Eigen::VectorXd& parameters) {
+  return (parameters.size() == parameterCount()) &&
+         (parameters[Parameters::kHorizontalResolutionRad] > 0.0) &&
+         (parameters[Parameters::kVerticalResolutionRad] > 0.0) &&
+         (parameters[Parameters::kVerticalCenterRad] >= 0.0) &&
+         (parameters[Parameters::kHorizontalCenterRad] >= 0.0);
+}
+
+bool CameraLidar3D::intrinsicsValid(const Eigen::VectorXd& intrinsics) const {
+  return areParametersValid(intrinsics);
+}
+
+void CameraLidar3D::printParameters(
+    std::ostream& out, const std::string& text) const {
+  Camera::printParameters(out, text);
+  out << "  horizontal angular resolution [rad]: " << horizontalResolution()
+      << std::endl;
+  out << "  vertical angular resolution [rad]: " << verticalResolution()
+      << std::endl;
+  out << "  line delay [ns]: " << line_delay_nanoseconds_ << std::endl;
+}
+
+const double CameraLidar3D::kSquaredMinimumDepth = 0.0001;
+
+bool CameraLidar3D::isValidImpl() const {
+  return intrinsicsValid(intrinsics_);
+}
+
+void CameraLidar3D::setRandomImpl() {
+  CameraLidar3D::Ptr test_camera = CameraLidar3D::createTestCamera();
+  CHECK(test_camera);
+  line_delay_nanoseconds_ = test_camera->line_delay_nanoseconds_;
+  image_width_ = test_camera->image_width_;
+  image_height_ = test_camera->image_height_;
+  mask_ = test_camera->mask_;
+  intrinsics_ = test_camera->intrinsics_;
+  camera_type_ = test_camera->camera_type_;
+  if (test_camera->distortion_) {
+    distortion_ = std::move(test_camera->distortion_);
+  }
+}
+
+bool CameraLidar3D::isEqualImpl(const Sensor& other, const bool verbose) const {
+  const CameraLidar3D* other_camera =
+      dynamic_cast<const CameraLidar3D*>(&other);
+  if (other_camera == nullptr) {
+    LOG_IF(ERROR, verbose) << "Other camera is not a CameraLidar3D!";
+    return false;
+  }
+
+  // Verify that the base members are equal.
+  if (!isEqualCameraImpl(*other_camera, verbose)) {
+    LOG_IF(ERROR, verbose) << "Base camera is not the same!";
+    return false;
+  }
+
+  // Compare the distortion model (if distortion is set for both).
+  if (!(*(this->distortion_) == *(other_camera->distortion_))) {
+    LOG_IF(ERROR, verbose) << "Distortion is not the same!";
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace aslam

--- a/aslam_cv_cameras/src/camera-factory.cc
+++ b/aslam_cv_cameras/src/camera-factory.cc
@@ -4,6 +4,7 @@
 
 #include <aslam/cameras/camera.h>
 #include <aslam/cameras/camera-pinhole.h>
+#include <aslam/cameras/camera-3d-lidar.h>
 #include <aslam/cameras/camera-unified-projection.h>
 #include <aslam/cameras/distortion-equidistant.h>
 #include <aslam/cameras/distortion-fisheye.h>
@@ -82,15 +83,16 @@ Camera::Ptr createCamera(const YAML::Node& yaml_node) {
 
   // Based on the type deserialize the camera
   Camera::Ptr camera;
-  if(camera_type == "pinhole") {
-    camera = std::dynamic_pointer_cast<Camera>(
-        aligned_shared<PinholeCamera>());
-  } else if(camera_type == "unified-projection") {
+  if (camera_type == "pinhole") {
+    camera = std::dynamic_pointer_cast<Camera>(aligned_shared<PinholeCamera>());
+  } else if (camera_type == "unified-projection") {
     camera = std::dynamic_pointer_cast<Camera>(
         aligned_shared<UnifiedProjectionCamera>());
+  } else if (camera_type == "lidar-3d") {
+    camera = std::dynamic_pointer_cast<Camera>(aligned_shared<CameraLidar3D>());
   } else {
     LOG(ERROR) << "Unknown camera model: \"" << camera_type << "\". "
-        << "Valid values are {pinhole, unified-projection}.";
+               << "Valid values are {pinhole, unified-projection, lidar-3d}.";
     return nullptr;
   }
 

--- a/aslam_cv_cameras/src/camera-factory.cc
+++ b/aslam_cv_cameras/src/camera-factory.cc
@@ -88,11 +88,11 @@ Camera::Ptr createCamera(const YAML::Node& yaml_node) {
   } else if (camera_type == "unified-projection") {
     camera = std::dynamic_pointer_cast<Camera>(
         aligned_shared<UnifiedProjectionCamera>());
-  } else if (camera_type == "lidar-3d") {
-    camera = std::dynamic_pointer_cast<Camera>(aligned_shared<CameraLidar3D>());
+  } else if (camera_type == "camera-3d-lidar") {
+    camera = std::dynamic_pointer_cast<Camera>(aligned_shared<Camera3DLidar>());
   } else {
     LOG(ERROR) << "Unknown camera model: \"" << camera_type << "\". "
-               << "Valid values are {pinhole, unified-projection, lidar-3d}.";
+               << "Valid values are {pinhole, unified-projection, camera-3d-lidar}.";
     return nullptr;
   }
 

--- a/aslam_cv_cameras/src/camera.cc
+++ b/aslam_cv_cameras/src/camera.cc
@@ -63,11 +63,29 @@ void Camera::printParameters(std::ostream& out, const std::string& text) const {
   out << "  image (cols,rows): " << imageWidth() << ", " << imageHeight() << std::endl;
 }
 
-bool Camera::isEqualCameraImpl(const Camera& other) const {
-  return (this->intrinsics_ == other.intrinsics_) &&
-         (this->line_delay_nanoseconds_ == other.line_delay_nanoseconds_) &&
-         (this->image_width_ == other.image_width_) &&
-         (this->image_height_ == other.image_height_);
+bool Camera::isEqualCameraImpl(const Camera& other, const bool verbose) const {
+  const bool is_same =
+      ((this->intrinsics_ - other.intrinsics_).norm() < 1e-6) &&
+      (this->line_delay_nanoseconds_ == other.line_delay_nanoseconds_) &&
+      (this->image_width_ == other.image_width_) &&
+      (this->image_height_ == other.image_height_);
+  if (verbose && !is_same) {
+    // clang-format off
+    LOG(ERROR) << "Cameras are not the same,"
+      << "\ncamera A:\n"
+        << this->intrinsics_.transpose() << "\n"
+        << this->line_delay_nanoseconds_ << "\n"
+        << this->image_width_ << "\n"
+        << this->image_height_
+      << "\ncamera B:\n"
+        << other.intrinsics_.transpose() << "\n"
+        << other.line_delay_nanoseconds_ << "\n"
+        << other.image_width_ << "\n"
+        << other.image_height_;
+    // clang-format on
+  }
+
+  return is_same;
 }
 
 bool Camera::loadFromYamlNodeImpl(const YAML::Node& yaml_node) {
@@ -158,6 +176,8 @@ bool Camera::loadFromYamlNodeImpl(const YAML::Node& yaml_node) {
     camera_type_ = Type::kPinhole;
   } else if(camera_type == "unified-projection") {
     camera_type_ = Type::kUnifiedProjection;
+  } else if(camera_type == "lidar-3d") {
+    camera_type_ = Type::kLidar3D;
   } else {
     LOG(ERROR) << "Unknown camera model: \"" << camera_type << "\". "
         << "Valid values are {pinhole, unified-projection}.";
@@ -212,6 +232,9 @@ void Camera::saveToYamlNodeImpl(YAML::Node* yaml_node) const {
       break;
     case aslam::Camera::Type::kUnifiedProjection:
       node["type"] = "unified-projection";
+      break;
+    case aslam::Camera::Type::kLidar3D:
+      node["type"] = "lidar-3d";
       break;
     default:
       LOG(ERROR) << "Unknown camera model: "

--- a/aslam_cv_cameras/src/camera.cc
+++ b/aslam_cv_cameras/src/camera.cc
@@ -176,7 +176,7 @@ bool Camera::loadFromYamlNodeImpl(const YAML::Node& yaml_node) {
     camera_type_ = Type::kPinhole;
   } else if(camera_type == "unified-projection") {
     camera_type_ = Type::kUnifiedProjection;
-  } else if(camera_type == "lidar-3d") {
+  } else if(camera_type == "camera-3d-lidar") {
     camera_type_ = Type::kLidar3D;
   } else {
     LOG(ERROR) << "Unknown camera model: \"" << camera_type << "\". "
@@ -198,14 +198,14 @@ bool Camera::loadFromYamlNodeImpl(const YAML::Node& yaml_node) {
   }
 
   // Get the optional linedelay in nanoseconds or set the default
-  if (!YAML::safeGet(yaml_node, "line-delay-nanoseconds", 
+  if (!YAML::safeGet(yaml_node, "line-delay-nanoseconds",
 				&line_delay_nanoseconds_)){
     LOG(WARNING)
         << "Unable to parse parameter line-delay-nanoseconds."
         << "Setting to default value = 0.";
     line_delay_nanoseconds_ = 0;
   }
-	
+
   // Get the optional compressed definition for images or set the default
   if (YAML::hasKey(yaml_node, "compressed")) {
 		if (!YAML::safeGet(yaml_node, "compressed", &is_compressed_)) {
@@ -234,7 +234,7 @@ void Camera::saveToYamlNodeImpl(YAML::Node* yaml_node) const {
       node["type"] = "unified-projection";
       break;
     case aslam::Camera::Type::kLidar3D:
-      node["type"] = "lidar-3d";
+      node["type"] = "camera-3d-lidar";
       break;
     default:
       LOG(ERROR) << "Unknown camera model: "

--- a/aslam_cv_cameras/test/test-camera-lidar-3d.cc
+++ b/aslam_cv_cameras/test/test-camera-lidar-3d.cc
@@ -1,0 +1,268 @@
+#include <Eigen/Core>
+#include <eigen-checks/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <typeinfo>
+
+#include <aslam/cameras/camera-3d-lidar.h>
+#include <aslam/cameras/camera-factory.h>
+#include <aslam/cameras/camera-pinhole.h>
+#include <aslam/cameras/camera-unified-projection.h>
+#include <aslam/cameras/camera.h>
+#include <aslam/cameras/distortion-equidistant.h>
+#include <aslam/cameras/distortion-fisheye.h>
+#include <aslam/cameras/distortion-null.h>
+#include <aslam/cameras/distortion-radtan.h>
+#include <aslam/cameras/distortion.h>
+#include <aslam/common/entrypoint.h>
+#include <aslam/common/memory.h>
+#include <aslam/common/numdiff-jacobian-tester.h>
+#include <aslam/common/yaml-serialization.h>
+
+///////////////////////////////////////////////
+// Types to test
+///////////////////////////////////////////////
+template <typename Camera, typename Distortion>
+struct CameraDistortion {
+  typedef Camera CameraType;
+  typedef Distortion DistortionType;
+};
+
+using testing::Types;
+typedef Types<CameraDistortion<aslam::CameraLidar3D, aslam::NullDistortion>>
+    Implementations;
+
+///////////////////////////////////////////////
+// Test fixture
+///////////////////////////////////////////////
+template <class CameraDistortion>
+class TestCameras : public testing::Test {
+ public:
+  typedef typename CameraDistortion::CameraType CameraType;
+  typedef typename CameraDistortion::DistortionType DistortionType;
+
+ protected:
+  TestCameras()
+      : camera_(CameraType::template createTestCamera<DistortionType>()){};
+  virtual ~TestCameras(){};
+  typename CameraType::Ptr camera_;
+};
+
+TYPED_TEST_CASE(TestCameras, Implementations);
+
+TYPED_TEST(TestCameras, isVisible) {
+  const double ru = this->camera_->imageWidth();
+  const double rv = this->camera_->imageHeight();
+
+  Eigen::Vector2d keypoint1(0, 0);
+  EXPECT_TRUE(this->camera_->isKeypointVisible(keypoint1))
+      << "Keypoint1: " << keypoint1;
+
+  Eigen::Vector2d keypoint2(ru - 1, rv - 1);
+  EXPECT_TRUE(this->camera_->isKeypointVisible(keypoint2))
+      << "Keypoint2: " << keypoint2;
+
+  Eigen::Vector2d keypoint4(-1, 0);
+  EXPECT_FALSE(this->camera_->isKeypointVisible(keypoint4))
+      << "Keypoint4: " << keypoint4;
+
+  Eigen::Vector2d keypoint5(-1, -1);
+  EXPECT_FALSE(this->camera_->isKeypointVisible(keypoint5))
+      << "Keypoint5: " << keypoint5;
+
+  Eigen::Vector3d keypoint6(ru, rv, 1);
+  EXPECT_FALSE(this->camera_->isKeypointVisible(keypoint6.head<2>()))
+      << "Keypoint6: " << keypoint6;
+}
+
+TYPED_TEST(TestCameras, isVisibleWithMargin) {
+  const double ru = this->camera_->imageWidth();
+  const double rv = this->camera_->imageHeight();
+  const double margin = 5.0;
+
+  Eigen::Vector2d keypoint1(margin, margin);
+  EXPECT_TRUE(this->camera_->isKeypointVisibleWithMargin(keypoint1, margin))
+      << "Keypoint1: " << keypoint1;
+
+  Eigen::Vector2d keypoint2(ru - 1 - margin, rv - 1 - margin);
+  EXPECT_TRUE(this->camera_->isKeypointVisibleWithMargin(keypoint2, margin))
+      << "Keypoint2: " << keypoint2;
+
+  Eigen::Vector2d keypoint4(0, 0);
+  EXPECT_FALSE(this->camera_->isKeypointVisibleWithMargin(keypoint4, margin))
+      << "Keypoint4: " << keypoint4;
+
+  Eigen::Vector2f keypoint5(ru - 1, rv - 1);
+  EXPECT_FALSE(this->camera_->isKeypointVisibleWithMargin(keypoint5, 5.0f))
+      << "Keypoint5: " << keypoint5;
+
+  Eigen::Vector3i keypoint6(ru, rv, 1);
+  EXPECT_FALSE(
+      this->camera_->isKeypointVisibleWithMargin(keypoint6.head<2>(), 5))
+      << "Keypoint6: " << keypoint6;
+}
+
+TYPED_TEST(TestCameras, isProjectable) {
+  EXPECT_TRUE(this->camera_->isProjectable3(
+      Eigen::Vector3d(2, -1, 20)));  // Approx. upper left corner.
+  EXPECT_TRUE(this->camera_->isProjectable3(
+      Eigen::Vector3d(2, 1, 20)));  // Approx. lower left corner.
+
+  EXPECT_TRUE(this->camera_->isProjectable3(
+      Eigen::Vector3d(0.001, -5.734907715, 20)));  // Approx. upper left corner.
+  EXPECT_TRUE(this->camera_->isProjectable3(
+      Eigen::Vector3d(0.001, 5.734907715, 20)));  // Approx. lower left corner.
+
+  EXPECT_FALSE(this->camera_->isProjectable3(
+      Eigen::Vector3d(0.001, -5.734907715, 2)));  // Outside image (too high)
+  EXPECT_FALSE(this->camera_->isProjectable3(
+      Eigen::Vector3d(0.001, 5.734907715, 2)));  // Outside image (too low)
+
+  EXPECT_TRUE(this->camera_->isProjectable3(
+      Eigen::Vector3d(0.001, 0, 1)));  // Left border
+  EXPECT_TRUE(this->camera_->isProjectable3(
+      Eigen::Vector3d(-0.001, 0, 1)));  // Right border
+  EXPECT_TRUE(
+      this->camera_->isProjectable3(Eigen::Vector3d(0.001, 0, -1)));  // Center
+  EXPECT_TRUE(
+      this->camera_->isProjectable3(Eigen::Vector3d(-0.001, 0, -1)));  // Center
+  EXPECT_TRUE(
+      this->camera_->isProjectable3(Eigen::Vector3d(1, 0, 0)));  // Right half
+  EXPECT_TRUE(
+      this->camera_->isProjectable3(Eigen::Vector3d(-1, 0, 0)));  // Left half.
+}
+
+TYPED_TEST(TestCameras, CameraTest_isInvertible) {
+  const int N = 100;
+  const double depth = 10.0;
+  Eigen::Matrix3Xd points1(3, N);
+  Eigen::Matrix2Xd projections1(2, N);
+  Eigen::Matrix3Xd points2(3, N);
+  Eigen::Matrix3Xd points3(3, N);
+  Eigen::Matrix2Xd projections3(2, N);
+  Eigen::Vector3d point;
+  Eigen::Vector2d keypoint;
+
+  // N times, project and back-project a random point at a known depth.
+  // Then check that the back projection matches the projection.
+  for (size_t n = 0; n < N; ++n) {
+    points1.col(n) = this->camera_->createRandomVisiblePoint(depth);
+    aslam::ProjectionResult result =
+        this->camera_->project3(points1.col(n), &keypoint);
+    projections1.col(n) = keypoint;
+
+    if (aslam::ProjectionResult::Status::KEYPOINT_VISIBLE !=
+        result.getDetailedStatus()) {
+      LOG(ERROR) << "Error could not project test point to image: 3DPoint "
+                 << points1.col(n).transpose() << " to img coord "
+                 << keypoint.transpose();
+      continue;
+    }
+    bool success = this->camera_->backProject3(keypoint, &point);
+    ASSERT_TRUE(success);
+    point.normalize();
+    points2.col(n) = point * depth;
+  }
+  // The distortion models are not invertible so we have to be generous here.
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(points1, points2, 1e-2));
+
+  // Do the same with the vectorized functions.
+  std::vector<aslam::ProjectionResult> result;
+  this->camera_->project3Vectorized(points1, &projections3, &result);
+  for (size_t n = 0; n < N; ++n) {
+    ASSERT_EQ(
+        aslam::ProjectionResult::Status::KEYPOINT_VISIBLE,
+        result[n].getDetailedStatus());
+  }
+  std::vector<unsigned char> success;
+  this->camera_->backProject3Vectorized(projections3, &points3, &success);
+  for (size_t n = 0; n < N; ++n) {
+    ASSERT_TRUE(success[n]);
+    points3.col(n).normalize();
+    points3.col(n) *= depth;
+  }
+  // The distortion models are not invertible so we have to be generous here.
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(points1, points3, 1e-2));
+}
+
+TYPED_TEST(TestCameras, TestClone) {
+  aslam::Camera::Ptr cam1(this->camera_->clone());
+
+  EXPECT_TRUE(this->camera_.get() != nullptr);  // Check both are valid objects.
+  EXPECT_TRUE(cam1.get() != nullptr);
+  EXPECT_TRUE(
+      this->camera_.get() !=
+      cam1.get());  // Check those are two different instances.
+  EXPECT_TRUE(
+      *(this->camera_) ==
+      *cam1);  // Check that the copy is the same as the original.
+
+  // Check that the distortion object is copied aswell.
+  EXPECT_TRUE(&this->camera_->getDistortion() != &cam1->getDistortion());
+  // Check that the copy is the same as the original.
+  EXPECT_TRUE(this->camera_->getDistortion() == cam1->getDistortion());
+}
+
+TYPED_TEST(TestCameras, invalidMaskTest) {
+  // Die on empty mask.
+  cv::Mat mask;
+  EXPECT_DEATH(this->camera_->setMask(mask), "^");
+
+  // Die on wrong type.
+  mask = cv::Mat::zeros(
+      cv::Size2i(this->camera_->imageWidth(), this->camera_->imageHeight()),
+      CV_8UC2);
+  EXPECT_DEATH(this->camera_->setMask(mask), "^");
+
+  // Die on wrong size.
+  mask = cv::Mat::zeros(
+      cv::Size2i(this->camera_->imageWidth() - 1, this->camera_->imageHeight()),
+      CV_8UC1);
+  EXPECT_DEATH(this->camera_->setMask(mask), "^");
+}
+
+TYPED_TEST(TestCameras, validMaskTest) {
+  cv::Mat mask = cv::Mat::ones(
+      cv::Size2i(this->camera_->imageWidth(), this->camera_->imageHeight()),
+      CV_8UC1);
+  mask.at<uint8_t>(20, 10) = 0;
+
+  EXPECT_FALSE(this->camera_->hasMask());
+  this->camera_->setMask(mask);
+  EXPECT_TRUE(this->camera_->hasMask());
+
+  typedef Eigen::Vector2d Vec2;
+  EXPECT_TRUE(this->camera_->isMasked(Vec2(-1., -1.)));
+  EXPECT_FALSE(this->camera_->isMasked(Vec2(0., 0.)));
+  EXPECT_TRUE(this->camera_->isMasked(
+      Vec2(this->camera_->imageWidth(), this->camera_->imageHeight())));
+  EXPECT_FALSE(this->camera_->isMasked(Vec2(
+      this->camera_->imageWidth() - 1.1, this->camera_->imageHeight() - 1.1)));
+  EXPECT_FALSE(
+      this->camera_->isMasked(Vec2(0.0, this->camera_->imageHeight() - 1.1)));
+  EXPECT_FALSE(
+      this->camera_->isMasked(Vec2(this->camera_->imageWidth() - 1.1, 0.0)));
+
+  // Check the valid/invalid.
+  EXPECT_FALSE(this->camera_->isMasked(Vec2(2.0, 2.0)));
+  EXPECT_FALSE(this->camera_->isMasked(Vec2(9.0, 19.0)));
+  EXPECT_FALSE(this->camera_->isMasked(Vec2(10.0, 19.0)));
+  EXPECT_FALSE(this->camera_->isMasked(Vec2(10.0, 21.0)));
+  EXPECT_FALSE(this->camera_->isMasked(Vec2(11.0, 21.0)));
+  EXPECT_FALSE(this->camera_->isMasked(Vec2(9.0, 21.0)));
+  EXPECT_TRUE(this->camera_->isMasked(Vec2(10.0, 20.0)));
+  EXPECT_TRUE(this->camera_->isMasked(Vec2(10.5, 20.5)));
+}
+
+TYPED_TEST(TestCameras, YamlSerialization) {
+  ASSERT_NE(this->camera_, nullptr);
+  this->camera_->serializeToFile("test.yaml");
+  typename TypeParam::CameraType::Ptr camera =
+      aligned_shared<typename TypeParam::CameraType>();
+  bool success = camera->deserializeFromFile("test.yaml");
+
+  EXPECT_TRUE(success);
+  EXPECT_TRUE(camera->isEqual(*this->camera_.get(), true));
+}
+
+ASLAM_UNITTEST_ENTRYPOINT


### PR DESCRIPTION
Introduces a camera model to project and backproject lidar point cloud. Tested for OS-1 64 beam and fully spherical camera.

The intrinsics are defined as:
 - Horizontal resolution [rad]
 - Vertical resolution [rad]
 - Horizontal center [rad]
 - Vertical center [rad]

The camera coordinate system follows the same convention as the other aslam_cv cameras: x right, y down, z forward. 

![image](https://user-images.githubusercontent.com/5071588/68533878-679ddf80-032e-11ea-991c-12a23b791028.png)
**Test example: OS-1 64 beam lidar scan from swiss mine tunnel**

![euroc_spherical](https://user-images.githubusercontent.com/5071588/68533737-d7ab6600-032c-11ea-93b7-d7bd9257dae7.png)
**Test example: EUROC ground truth point cloud projected into fully spherical depth camera at the center of the room**


Sensor format (Example Ouster OS-1 64 beam):
```yaml
  - id: ccccbac2a7c5fad79f09e49e3b96d87c
    sensor_type: NCAMERA
    description: "Lidarstick - OS-1 camera model"
    topic: ""
    cameras:
      - camera:
          id: aaaab5000f15adb3c0da8ac6b729ee05
          sensor_type: CAMERA
          description: "Lidarstick - OS-1 64 beam lidar - camera model"
          topic: ""
          line-delay-nanoseconds: 97656
          image_height: 64
          image_width: 1024
          type: camera-3d-lidar
          intrinsics:
            # kHorizontalResolutionRad      0.351562 deg
            # kVerticalResolutionRad        0.527333 deg
            # kVerticalCenterRad            16.611   deg
            # kHorizontalCenterRad          0        deg
            rows: 4
            cols: 1
            data:
              - 0.006135923
              - 0.009203703
              - 0.289916642
              - 0.
        T_B_C:
          rows: 4
          cols: 4
          data:
            - [ 0.0,  0.0,  1.0,  0.0]
            - [-1.0,  0.0,  0.0,  0.0]
            - [ 0.0, -1.0,  0.0,  0.0]
            - [ 0.0,  0.0,  0.0,  1.0]
```

**TODOs / Future Work (?)**

 - [ ] implement the jacobians as well
 - [ ] make model more precise (e.g. compensate for irregular altitude/azimuth steps)
 - [ ] unify unit tests of lidar cam and other cams