### PR TITLE
Fix camera check with verbosity output

### DIFF
--- a/aslam_cv_cameras/src/ncamera.cc
+++ b/aslam_cv_cameras/src/ncamera.cc
@@ -419,13 +419,13 @@ bool NCamera::isEqualImpl(const Sensor& other, const bool verbose) const {
           other_ncamera->T_C_B_[i].getTransformationMatrix())
              .cwiseAbs()
              .maxCoeff() < common::macros::kEpsilon);
+    is_equal &= is_same_camera && has_same_camera_extrinsics;
+
     if (verbose && !is_equal) {
       LOG(ERROR) << "Camera at idx " << i << " is not the same:"
                  << "\n\tsame camera object: " << is_same_camera
                  << "\n\tsame extrinsics:    " << has_same_camera_extrinsics;
     }
-
-    is_equal &= is_same_camera && has_same_camera_extrinsics;
   }
   return is_equal;
 }


### PR DESCRIPTION
## General
This PR fixes the output when a camera is not equal to another. Previously, it would show the output for the previous camera or nothing if the last camera was not equal. 

## Changelog
* moved output statement to the correct place