### PR TITLE
Adding a configurable number of feature channels

### DIFF
--- a/aslam_cv_common/include/aslam/common/channel-declaration.h
+++ b/aslam_cv_common/include/aslam/common/channel-declaration.h
@@ -37,6 +37,34 @@ NAME##_ChannelValueType& get_##NAME##_Data(                                \
   return derived->value_;                                                  \
 }                                                                          \
                                                                            \
+void serialize_##NAME##_Channel(                                           \
+    const ChannelGroup& channel_group, std::string* data) {                \
+  std::lock_guard<std::mutex> lock(channel_group.m_channels_);             \
+  const ChannelMap& channels = channel_group.channels_;                    \
+  ChannelMap::const_iterator it = channels.find(NAME##_CHANNEL);           \
+  CHECK(it != channels.end()) << "Channelgroup does not "                  \
+      "contain channel " << NAME##_CHANNEL;                                \
+  std::shared_ptr<NAME##_ChannelType> derived =                            \
+     std::dynamic_pointer_cast<NAME##_ChannelType>(it->second);            \
+  CHECK(derived) << "Channel cast to derived failed " <<                   \
+     "channel: " << NAME##_CHANNEL;                                        \
+  derived->serializeToString(data);                                        \
+}                                                                          \
+                                                                           \
+void deserialize_##NAME##_Channel(                                         \
+    const ChannelGroup& channel_group, const std::string& data) {          \
+  std::lock_guard<std::mutex> lock(channel_group.m_channels_);             \
+  const ChannelMap& channels = channel_group.channels_;                    \
+  ChannelMap::const_iterator it = channels.find(NAME##_CHANNEL);           \
+  CHECK(it != channels.end()) << "Channelgroup does not "                  \
+      "contain channel " << NAME##_CHANNEL;                                \
+  std::shared_ptr<NAME##_ChannelType> derived =                            \
+     std::dynamic_pointer_cast<NAME##_ChannelType>(it->second);            \
+  CHECK(derived) << "Channel cast to derived failed " <<                   \
+     "channel: " << NAME##_CHANNEL;                                        \
+  derived->deSerializeFromString(data);                                    \
+}                                                                          \
+                                                                           \
 NAME##_ChannelValueType& add_##NAME##_Channel(                             \
     ChannelGroup* channel_group) {                                         \
   CHECK_NOTNULL(channel_group);                                            \

--- a/aslam_cv_common/include/aslam/common/channel-definitions.h
+++ b/aslam_cv_common/include/aslam/common/channel-definitions.h
@@ -24,17 +24,22 @@ DECLARE_CHANNEL(VISUAL_KEYPOINT_SCALES, Eigen::VectorXd)
 /// sorting or subsampling. (keypoint detector output)
 DECLARE_CHANNEL(VISUAL_KEYPOINT_SCORES, Eigen::VectorXd)
 
+// 3D position of the 2D keypoint as provided by a depth sensor and also a time
+// offset for the point with respect to the time in the frame
+DECLARE_CHANNEL(VISUAL_KEYPOINT_3D_POSITIONS, Eigen::Matrix3Xd)
+DECLARE_CHANNEL(VISUAL_KEYPOINT_TIME_OFFSETS, Eigen::VectorXi)
+
 /// The keypoint descriptors. (extractor output)
 /// (cols are descriptors)
 DECLARE_CHANNEL(DESCRIPTORS,
-                Eigen::Matrix<unsigned char, Eigen::Dynamic, Eigen::Dynamic>)
+                std::vector<Eigen::Matrix<unsigned char, Eigen::Dynamic, Eigen::Dynamic>>)
+DECLARE_CHANNEL(DESCRIPTOR_TYPES, Eigen::VectorXi)
 
-/// Track ID's for tracked features. (-1 if not tracked); (feature tracker output)
+/// Track IDs for tracked features. (-1 if not tracked); (feature tracker output)
 DECLARE_CHANNEL(TRACK_IDS, Eigen::VectorXi)
 
 /// The raw image.
 DECLARE_CHANNEL(RAW_IMAGE, cv::Mat)
-
 DECLARE_CHANNEL(CV_MAT, cv::Mat)
 
 #endif  // ASLAM_CV_COMMON_CHANNEL_DEFINITIONS_H_

--- a/aslam_cv_common/test/test-channel-serialization.cc
+++ b/aslam_cv_common/test/test-channel-serialization.cc
@@ -144,6 +144,47 @@ TYPED_TEST(ChannelSerializationTest, SerializeDeserializeBuffer) {
   EXPECT_TRUE(EIGEN_MATRIX_NEAR(this->value_a.value_, this->value_b.value_, static_cast<Scalar>(1e-4)));
 }
 
+TEST(MatrixVectorChannelSerialization, SerializeDeserializeString) {
+  typedef Eigen::Matrix<unsigned char, Eigen::Dynamic, Eigen::Dynamic> DescriptorsT;
+  aslam::channels::Channel<std::vector<DescriptorsT>> value_a;
+  aslam::channels::Channel<std::vector<DescriptorsT>> value_b;
+
+  for (size_t i = 0; i < 5; i++) {
+    value_a.value_.emplace_back(i*2+10, i*3+5);
+    value_a.value_[i].setRandom();
+  }
+
+  char* buffer;
+  size_t size;
+  EXPECT_TRUE(value_a.serializeToBuffer(&buffer, &size));
+  EXPECT_TRUE(value_b.deSerializeFromBuffer(buffer, size));
+  ASSERT_EQ(value_a.value_.size(), value_b.value_.size());
+  for (size_t i = 0; i < value_a.value_.size(); i++) {
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        value_a.value_[i], value_b.value_[i], static_cast<unsigned char>(1e-4)));
+  }
+}
+
+TEST(MatrixVectorChannelSerialization, SerializeDeserializeBuffer) {
+  typedef Eigen::Matrix<unsigned char, Eigen::Dynamic, Eigen::Dynamic> DescriptorsT;
+  aslam::channels::Channel<std::vector<DescriptorsT>> value_a;
+  aslam::channels::Channel<std::vector<DescriptorsT>> value_b;
+
+  for (size_t i = 0; i < 5; i++) {
+    value_a.value_.emplace_back(i*2+10, i*3+5);
+    value_a.value_[i].setRandom();
+  }
+
+  std::string serialized_value;
+  EXPECT_TRUE(value_a.serializeToString(&serialized_value));
+  EXPECT_TRUE(value_b.deSerializeFromString(serialized_value));
+  ASSERT_EQ(value_a.value_.size(), value_b.value_.size());
+  for (size_t i = 0; i < value_a.value_.size(); i++) {
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        value_a.value_[i], value_b.value_[i], static_cast<unsigned char>(1e-4)));
+  }
+}
+
 TEST(ChannelSerialization, HeaderInfoSize) {
   aslam::internal::HeaderInformation header_info;
   header_info.cols = 12;

--- a/aslam_cv_frames/include/aslam/frames/feature-track.h
+++ b/aslam_cv_frames/include/aslam/frames/feature-track.h
@@ -30,7 +30,7 @@ class FeatureTrack {
     double v_max = std::numeric_limits<double>::min();
 
     for (const KeypointIdentifier& kid : getKeypointIdentifiers()) {
-      const Eigen::Block<Eigen::Matrix2Xd, 2, 1> keypoint = kid.getKeypointMeasurement();
+      const Eigen::Block<const Eigen::Matrix2Xd, 2, 1> keypoint = kid.getKeypointMeasurement();
       u_min = std::min(u_min, keypoint(0));
       u_max = std::max(u_max, keypoint(0));
       v_min = std::min(v_min, keypoint(1));

--- a/aslam_cv_frames/include/aslam/frames/keypoint-identifier.h
+++ b/aslam_cv_frames/include/aslam/frames/keypoint-identifier.h
@@ -51,7 +51,7 @@ class KeypointIdentifier {
   inline const aslam::VisualFrame& getFrame() const { return nframe_->getFrame(frame_index_); }
   inline const aslam::VisualNFrame& getNFrame() const { return *nframe_; }
 
-  const Eigen::Block<Eigen::Matrix2Xd, 2, 1> getKeypointMeasurement() const {
+  const Eigen::Block<const Eigen::Matrix2Xd, 2, 1> getKeypointMeasurement() const {
     return nframe_->getFrame(frame_index_).getKeypointMeasurement(keypoint_index_);
   }
 

--- a/aslam_cv_frames/include/aslam/frames/visual-frame.h
+++ b/aslam_cv_frames/include/aslam/frames/visual-frame.h
@@ -78,6 +78,12 @@ class VisualFrame  {
   /// Are there keypoint scales stored in this frame?
   bool hasKeypointScales() const;
 
+  /// Are there any 3D measurements stored in this frame?
+  bool hasKeypoint3DPositions() const;
+
+  /// Are there any time offsets stored in this frame?
+  bool hasKeypointTimeOffsets() const;
+
   /// Are there descriptors stored in this frame?
   bool hasDescriptors() const;
 
@@ -104,6 +110,8 @@ class VisualFrame  {
     return hasKeypointMeasurements() ? getKeypointMeasurements().cols() : 0u;
   }
 
+  size_t getNumDescriptors() const;
+
   /// The keypoint measurement uncertainties stored in a frame.
   const Eigen::VectorXd& getKeypointMeasurementUncertainties() const;
 
@@ -116,8 +124,14 @@ class VisualFrame  {
   /// The keypoint scales stored in a frame.
   const Eigen::VectorXd& getKeypointScales() const;
 
+  /// The keypoint 3D measurements stored in a frame.
+  const Eigen::Matrix3Xd& getKeypoint3DPositions() const;
+
+  /// The keypoint time offsets stored in a frame.
+  const Eigen::VectorXi& getKeypointTimeOffsets() const;
+
   /// The descriptors stored in a frame.
-  const DescriptorsT& getDescriptors() const;
+  const DescriptorsT& getDescriptors(size_t index = 0) const;
 
   /// The track ids stored in this frame.
   const Eigen::VectorXi& getTrackIds() const;
@@ -148,8 +162,14 @@ class VisualFrame  {
   /// A pointer to the keypoint scales, can be used to swap in new data.
   Eigen::VectorXd* getKeypointScalesMutable();
 
+  /// A pointer to the keypoint 3D positions, can be used to swap in new data.
+  Eigen::Matrix3Xd* getKeypoint3DPositionsMutable();
+
+  /// A pointer to the keypoint time offsets, can be used to swap in new data.
+  Eigen::VectorXi* getKeypointTimeOffsetsMutable();
+
   /// A pointer to the descriptors, can be used to swap in new data.
-  DescriptorsT* getDescriptorsMutable();
+  DescriptorsT* getDescriptorsMutable(size_t index = 0);
 
   /// A pointer to the track ids, can be used to swap in new data.
   Eigen::VectorXi* getTrackIdsMutable();
@@ -166,7 +186,7 @@ class VisualFrame  {
   }
 
   /// Return block expression of the keypoint measurement pointed to by index.
-  const Eigen::Block<Eigen::Matrix2Xd, 2, 1> getKeypointMeasurement(size_t index) const;
+  const Eigen::Block<const Eigen::Matrix2Xd, 2, 1> getKeypointMeasurement(size_t index) const;
 
   /// Return the keypoint measurement uncertainty at index.
   double getKeypointMeasurementUncertainty(size_t index) const;
@@ -179,6 +199,12 @@ class VisualFrame  {
 
   /// Return the keypoint scale at index.
   double getKeypointScale(size_t index) const;
+
+  /// Return block expression of the keypoint 3D position pointed to by index.
+  const Eigen::Block<const Eigen::Matrix3Xd, 3, 1> getKeypoint3DPosition(size_t index) const;
+
+  /// Return the keypoint timeoffset at index.
+  int getKeypointTimeOffset(size_t index) const;
 
   /// Return pointer location of the descriptor pointed to by index.
   const unsigned char* getDescriptor(size_t index) const;
@@ -202,11 +228,16 @@ class VisualFrame  {
   /// Replace (copy) the internal keypoint orientations by the passed ones.
   void setKeypointScales(const Eigen::VectorXd& scales);
 
-  /// Replace (copy) the internal descriptors by the passed ones.
-  void setDescriptors(const DescriptorsT& descriptors);
+  /// Replace (copy) the internal keypoint 3D positions by the passed ones.
+  void setKeypoint3DPositions(const Eigen::Matrix3Xd& positions);
+
+  /// Replace (copy) the internal track ids by the passed ones.
+  void setKeypointTimeOffsets(const Eigen::VectorXi& offsets);
 
   /// Replace (copy) the internal descriptors by the passed ones.
-  void setDescriptors(const Eigen::Map<const DescriptorsT>& descriptors);
+  template <typename Derived>
+  void setDescriptors(const Derived& descriptors, size_t index = 0,
+                      int descriptor_type = 0);
 
   /// Replace (copy) the internal track ids by the passed ones.
   void setTrackIds(const Eigen::VectorXi& track_ids);
@@ -244,8 +275,17 @@ class VisualFrame  {
   /// Replace (swap) the internal keypoint orientations by the passed ones.
   void swapKeypointScales(Eigen::VectorXd* scales);
 
+  /// Replace (swap) the internal keypoint 3D positions by the passed ones.
+  /// This method creates the channel if it doesn't exist
+  void swapKeypoint3DPositions(Eigen::Matrix3Xd* positions);
+
+  /// Replace (swap) the internal keypoint timeoffsets by the passed ones.
+  void swapKeypointTimeOffsets(Eigen::VectorXi* offsets);
+
   /// Replace (swap) the internal descriptors by the passed ones.
-  void swapDescriptors(DescriptorsT* descriptors);
+  /// Returns the type of the swapped out descriptor
+  int swapDescriptors(DescriptorsT* descriptors, size_t index = 0,
+                       int descriptor_type = 0);
 
   /// Replace (swap) the internal track ids by the passed ones.
   void swapTrackIds(Eigen::VectorXi* track_ids);
@@ -327,7 +367,7 @@ class VisualFrame  {
   }
 
   /// Set the size of the descriptor in bytes.
-  size_t getDescriptorSizeBytes() const;
+  size_t getDescriptorSizeBytes(size_t index = 0) const;
 
   /// Set the validity flag to true.
   void validate() { is_valid_ = true; }
@@ -341,6 +381,11 @@ class VisualFrame  {
   /// Print out a human-readable version of this frame
   void print(std::ostream& out, const std::string& label) const;
 
+  /// Lock frame for processing, a matching call to unlock() must exist
+  void lock() { m_frame_lock_.lock(); }
+  /// Unlock a locked frame, must be called after lock
+  void unlock() { m_frame_lock_.unlock(); }
+
   /// \brief Creates an empty frame. The following channels are added without any data attached:
   ///        {KeypointMeasurements, KeypointMeasurementUncertainties, Descriptors}
   /// @param[in]  camera                  Camera which will be assigned to the frame.
@@ -351,6 +396,68 @@ class VisualFrame  {
 
   void discardUntrackedObservations(std::vector<size_t>* discarded_indices);
 
+  /* Experimental functions for dealing with multiple types of different
+     features in the same channel, including different feature sizes */
+  void extendKeypointMeasurements(const Eigen::Matrix2Xd& keypoints_new);
+  void extendKeypointMeasurementUncertainties(
+      const Eigen::VectorXd& uncertainties_new, double default_value = 0.0);
+  void extendKeypointOrientations(
+      const Eigen::VectorXd& orientations_new, double default_value = 0.0);
+  void extendKeypointScores(
+      const Eigen::VectorXd& scores_new, double default_value = 0.0);
+  void extendKeypointScales(
+      const Eigen::VectorXd& scales_new, double default_value = 0.0);
+  void extendKeypoint3DPositions(
+      const Eigen::Matrix3Xd& positions_new, double default_value = 0.0);
+  void extendKeypointTimeOffsets(
+      const Eigen::VectorXi& offsets_new, int default_value = -1);
+  template <typename Derived>
+  void extendDescriptors(const Derived& descriptors_new, int descriptor_type = 0);
+  void extendTrackIds(const Eigen::VectorXi& track_ids_new, int default_value = -1);
+
+  void serializeDescriptorsToString(std::string* descriptors_string) const;
+  void deserializeDescriptorsFromString(const std::string& descriptors_string);
+
+  bool hasDescriptorType(int descriptor_type) const;
+  void setDescriptorTypes(const Eigen::VectorXi& descriptor_types);
+  const Eigen::VectorXi& getDescriptorTypes() const;
+  int getDescriptorType(size_t index) const;
+  int getDescriptorBlockType(size_t block) const;
+  void getDescriptorBlockTypeStartAndSize(
+      int descriptor_type, size_t *start, size_t *size) const;
+  size_t getDescriptorTypeBlock(int descriptor_type) const;
+  size_t getDescriptorTypeSizeBytes(int descriptor_type) const;
+
+  size_t getNumKeypointMeasurementsOfType(int descriptor_type) const;
+  const Eigen::Block<const Eigen::Matrix2Xd> getKeypointMeasurementsOfType(
+      int descriptor_type) const;
+  const Eigen::VectorBlock<const Eigen::VectorXd> getKeypointMeasurementUncertaintiesOfType(
+      int descriptor_type) const;
+  const Eigen::VectorBlock<const Eigen::VectorXd> getKeypointOrientationsOfType(
+      int descriptor_type) const;
+  const Eigen::VectorBlock<const Eigen::VectorXd> getKeypointScoresOfType(
+      int descriptor_type) const;
+  const Eigen::VectorBlock<const Eigen::VectorXd> getKeypointScalesOfType(
+      int descriptor_type) const;
+  const Eigen::Block<const Eigen::Matrix3Xd> getKeypoint3DPositionsOfType(
+      int descriptor_type) const;
+  const Eigen::VectorBlock<const Eigen::VectorXi> getKeypointTimeOffsetsOfType(
+      int descriptor_type) const;
+  const DescriptorsT& getDescriptorsOfType(int descriptor_type) const;
+  const Eigen::VectorBlock<const Eigen::VectorXi> getTrackIdsOfType(
+      int descriptor_type) const;
+
+  const Eigen::Block<const Eigen::Matrix2Xd, 2, 1> getKeypointMeasurementOfType(
+      size_t index, int descriptor_type) const;
+  double getKeypointMeasurementUncertaintyOfType(size_t index, int descriptor_type) const;
+  double getKeypointOrientationOfType(size_t index, int descriptor_type) const;
+  double getKeypointScaleOfType(size_t index, int descriptor_type) const;
+  double getKeypointScoreOfType(size_t index, int descriptor_type) const;
+  const Eigen::Block<const Eigen::Matrix3Xd, 3, 1> getKeypoint3DPositionOfType(
+      size_t index, int descriptor_type) const;
+  int getKeypointTimeOffsetOfType(size_t index, int descriptor_type) const;
+  int getTrackIdOfType(size_t index, int descriptor_type) const;
+
  private:
   /// Timestamp in nanoseconds.
   int64_t timestamp_nanoseconds_;
@@ -359,6 +466,9 @@ class VisualFrame  {
   aslam::channels::ChannelGroup channels_;
   Camera::ConstPtr camera_geometry_;
   Camera::ConstPtr raw_camera_geometry_;
+
+  // Provides capability to lock frame for processing in parallelized system
+  std::mutex m_frame_lock_;
 
   /// Validity flag: can be used by an external algorithm to flag frames that should
   /// be excluded/included when processing a list of frames. Does not have any internal

--- a/aslam_cv_frames/src/visual-frame.cc
+++ b/aslam_cv_frames/src/visual-frame.cc
@@ -62,6 +62,12 @@ bool VisualFrame::hasKeypointScores() const {
 bool VisualFrame::hasKeypointScales() const{
   return aslam::channels::has_VISUAL_KEYPOINT_SCALES_Channel(channels_);
 }
+bool VisualFrame::hasKeypoint3DPositions() const{
+  return aslam::channels::has_VISUAL_KEYPOINT_3D_POSITIONS_Channel(channels_);
+}
+bool VisualFrame::hasKeypointTimeOffsets() const{
+  return aslam::channels::has_VISUAL_KEYPOINT_TIME_OFFSETS_Channel(channels_);
+}
 bool VisualFrame::hasDescriptors() const{
   return aslam::channels::has_DESCRIPTORS_Channel(channels_);
 }
@@ -78,17 +84,26 @@ const Eigen::Matrix2Xd& VisualFrame::getKeypointMeasurements() const {
 const Eigen::VectorXd& VisualFrame::getKeypointMeasurementUncertainties() const {
   return aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Data(channels_);
 }
-const Eigen::VectorXd& VisualFrame::getKeypointScales() const {
-  return aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
-}
 const Eigen::VectorXd& VisualFrame::getKeypointOrientations() const {
   return aslam::channels::get_VISUAL_KEYPOINT_ORIENTATIONS_Data(channels_);
 }
 const Eigen::VectorXd& VisualFrame::getKeypointScores() const {
   return aslam::channels::get_VISUAL_KEYPOINT_SCORES_Data(channels_);
 }
-const VisualFrame::DescriptorsT& VisualFrame::getDescriptors() const {
-  return aslam::channels::get_DESCRIPTORS_Data(channels_);
+const Eigen::VectorXd& VisualFrame::getKeypointScales() const {
+  return aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
+}
+const Eigen::Matrix3Xd& VisualFrame::getKeypoint3DPositions() const {
+  return aslam::channels::get_VISUAL_KEYPOINT_3D_POSITIONS_Data(channels_);
+}
+const Eigen::VectorXi& VisualFrame::getKeypointTimeOffsets() const {
+  return aslam::channels::get_VISUAL_KEYPOINT_TIME_OFFSETS_Data(channels_);
+}
+const VisualFrame::DescriptorsT& VisualFrame::getDescriptors(size_t index) const {
+  const std::vector<VisualFrame::DescriptorsT>& data =
+      aslam::channels::get_DESCRIPTORS_Data(channels_);
+  CHECK_LT(index, data.size());
+  return data[index];
 }
 const Eigen::VectorXi& VisualFrame::getTrackIds() const {
   return aslam::channels::get_TRACK_IDS_Data(channels_);
@@ -104,32 +119,43 @@ void VisualFrame::releaseRawImage() {
 Eigen::Matrix2Xd* VisualFrame::getKeypointMeasurementsMutable() {
   Eigen::Matrix2Xd& keypoints =
       aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENTS_Data(channels_);
-    return &keypoints;
+  return &keypoints;
 }
 Eigen::VectorXd* VisualFrame::getKeypointMeasurementUncertaintiesMutable() {
   Eigen::VectorXd& uncertainties =
       aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Data(channels_);
-    return &uncertainties;
+  return &uncertainties;
 }
 Eigen::VectorXd* VisualFrame::getKeypointScalesMutable() {
   Eigen::VectorXd& scales =
       aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
-    return &scales;
+  return &scales;
 }
 Eigen::VectorXd* VisualFrame::getKeypointOrientationsMutable() {
   Eigen::VectorXd& orientations =
       aslam::channels::get_VISUAL_KEYPOINT_ORIENTATIONS_Data(channels_);
-    return &orientations;
+  return &orientations;
 }
 Eigen::VectorXd* VisualFrame::getKeypointScoresMutable() {
   Eigen::VectorXd& scores =
       aslam::channels::get_VISUAL_KEYPOINT_SCORES_Data(channels_);
-    return &scores;
+  return &scores;
 }
-VisualFrame::DescriptorsT* VisualFrame::getDescriptorsMutable() {
-  VisualFrame::DescriptorsT& descriptors =
+Eigen::Matrix3Xd* VisualFrame::getKeypoint3DPositionsMutable() {
+  Eigen::Matrix3Xd& positions =
+      aslam::channels::get_VISUAL_KEYPOINT_3D_POSITIONS_Data(channels_);
+  return &positions;
+}
+Eigen::VectorXi* VisualFrame::getKeypointTimeOffsetsMutable() {
+  Eigen::VectorXi& time_offsets =
+      aslam::channels::get_VISUAL_KEYPOINT_TIME_OFFSETS_Data(channels_);
+  return &time_offsets;
+}
+VisualFrame::DescriptorsT* VisualFrame::getDescriptorsMutable(size_t index) {
+  std::vector<VisualFrame::DescriptorsT>& data =
       aslam::channels::get_DESCRIPTORS_Data(channels_);
-  return &descriptors;
+  CHECK_LT(index, data.size());
+  return &data[index];
 }
 Eigen::VectorXi* VisualFrame::getTrackIdsMutable() {
   Eigen::VectorXi& track_ids =
@@ -142,45 +168,73 @@ cv::Mat* VisualFrame::getRawImageMutable() {
   return &image;
 }
 
-const Eigen::Block<Eigen::Matrix2Xd, 2, 1>
+const Eigen::Block<const Eigen::Matrix2Xd, 2, 1>
 VisualFrame::getKeypointMeasurement(size_t index) const {
-  Eigen::Matrix2Xd& keypoints =
+  const Eigen::Matrix2Xd& keypoints =
       aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENTS_Data(channels_);
   CHECK_LT(static_cast<int>(index), keypoints.cols());
   return keypoints.block<2, 1>(0, index);
 }
 double VisualFrame::getKeypointMeasurementUncertainty(size_t index) const {
-  Eigen::VectorXd& data =
+  const Eigen::VectorXd& data =
       aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Data(channels_);
   CHECK_LT(static_cast<int>(index), data.rows());
   return data.coeff(index, 0);
 }
-double VisualFrame::getKeypointScale(size_t index) const {
-  Eigen::VectorXd& data =
-      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
-  CHECK_LT(static_cast<int>(index), data.rows());
-  return data.coeff(index, 0);
-}
 double VisualFrame::getKeypointOrientation(size_t index) const {
-  Eigen::VectorXd& data =
+  const Eigen::VectorXd& data =
       aslam::channels::get_VISUAL_KEYPOINT_ORIENTATIONS_Data(channels_);
   CHECK_LT(static_cast<int>(index), data.rows());
   return data.coeff(index, 0);
 }
 double VisualFrame::getKeypointScore(size_t index) const {
-  Eigen::VectorXd& data =
+  const Eigen::VectorXd& data =
       aslam::channels::get_VISUAL_KEYPOINT_SCORES_Data(channels_);
   CHECK_LT(static_cast<int>(index), data.rows());
   return data.coeff(index, 0);
 }
-const unsigned char* VisualFrame::getDescriptor(size_t index) const {
-  VisualFrame::DescriptorsT& descriptors =
-      aslam::channels::get_DESCRIPTORS_Data(channels_);
-  CHECK_LT(static_cast<int>(index), descriptors.cols());
-  return &descriptors.coeffRef(0, index);
+double VisualFrame::getKeypointScale(size_t index) const {
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
+  CHECK_LT(static_cast<int>(index), data.rows());
+  return data.coeff(index, 0);
 }
+const Eigen::Block<const Eigen::Matrix3Xd, 3, 1>
+VisualFrame::getKeypoint3DPosition(size_t index) const {
+  const Eigen::Matrix3Xd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_3D_POSITIONS_Data(channels_);
+  CHECK_LT(static_cast<int>(index), data.cols());
+  return data.block<3, 1>(0, index);
+}
+int VisualFrame::getKeypointTimeOffset(size_t index) const {
+  const Eigen::VectorXi& data =
+      aslam::channels::get_VISUAL_KEYPOINT_TIME_OFFSETS_Data(channels_);
+  CHECK_LT(static_cast<int>(index), data.rows());
+  return data.coeff(index, 0);
+}
+
+size_t getDescriptorBlockForIndex(
+    const std::vector<VisualFrame::DescriptorsT>& descriptors, size_t *index) {
+  for (size_t block = 0u; block < descriptors.size(); ++block) {
+    const size_t num_descriptors = static_cast<int>(descriptors[block].cols());
+    if (*index < num_descriptors) {
+      return block;
+    }
+    *index -= num_descriptors;
+  }
+
+  LOG(FATAL) << "Descriptor index out of range";
+}
+
+const unsigned char* VisualFrame::getDescriptor(size_t index) const {
+  const std::vector<VisualFrame::DescriptorsT>& descriptors =
+      aslam::channels::get_DESCRIPTORS_Data(channels_);
+  size_t block = getDescriptorBlockForIndex(descriptors, &index);
+  return &descriptors[block].coeffRef(0, index);
+}
+
 int VisualFrame::getTrackId(size_t index) const {
-  Eigen::VectorXi& track_ids =
+  const Eigen::VectorXi& track_ids =
       aslam::channels::get_TRACK_IDS_Data(channels_);
   CHECK_LT(static_cast<int>(index), track_ids.rows());
   return track_ids.coeff(index, 0);
@@ -204,15 +258,6 @@ void VisualFrame::setKeypointMeasurementUncertainties(
       aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Data(channels_);
   data = uncertainties_new;
 }
-void VisualFrame::setKeypointScales(
-    const Eigen::VectorXd& scales_new) {
-  if (!aslam::channels::has_VISUAL_KEYPOINT_SCALES_Channel(channels_)) {
-    aslam::channels::add_VISUAL_KEYPOINT_SCALES_Channel(&channels_);
-  }
-  Eigen::VectorXd& data =
-      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
-  data = scales_new;
-}
 void VisualFrame::setKeypointOrientations(
     const Eigen::VectorXd& orientations_new) {
   if (!aslam::channels::has_VISUAL_KEYPOINT_ORIENTATIONS_Channel(channels_)) {
@@ -231,24 +276,62 @@ void VisualFrame::setKeypointScores(
       aslam::channels::get_VISUAL_KEYPOINT_SCORES_Data(channels_);
   data = scores_new;
 }
+void VisualFrame::setKeypointScales(
+    const Eigen::VectorXd& scales_new) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_SCALES_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_SCALES_Channel(&channels_);
+  }
+  Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
+  data = scales_new;
+}
+void VisualFrame::setKeypoint3DPositions(
+    const Eigen::Matrix3Xd& positions_new) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_3D_POSITIONS_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_3D_POSITIONS_Channel(&channels_);
+  }
+  Eigen::Matrix3Xd& positions =
+      aslam::channels::get_VISUAL_KEYPOINT_3D_POSITIONS_Data(channels_);
+  positions = positions_new;
+}
+void VisualFrame::setKeypointTimeOffsets(const Eigen::VectorXi& offsets_new) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_TIME_OFFSETS_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_TIME_OFFSETS_Channel(&channels_);
+  }
+  Eigen::VectorXi& offsets =
+      aslam::channels::get_VISUAL_KEYPOINT_TIME_OFFSETS_Data(channels_);
+  offsets = offsets_new;
+}
+
+template <typename Derived>
 void VisualFrame::setDescriptors(
-    const DescriptorsT& descriptors_new) {
+    const Derived& descriptors_new, size_t index, int descriptor_type) {
   if (!aslam::channels::has_DESCRIPTORS_Channel(channels_)) {
     aslam::channels::add_DESCRIPTORS_Channel(&channels_);
+    aslam::channels::add_DESCRIPTOR_TYPES_Channel(&channels_);
   }
-  VisualFrame::DescriptorsT& descriptors =
+  std::vector<VisualFrame::DescriptorsT>& descriptors =
       aslam::channels::get_DESCRIPTORS_Data(channels_);
-  descriptors = descriptors_new;
-}
-void VisualFrame::setDescriptors(
-    const Eigen::Map<const DescriptorsT>& descriptors_new) {
-  if (!aslam::channels::has_DESCRIPTORS_Channel(channels_)) {
-    aslam::channels::add_DESCRIPTORS_Channel(&channels_);
+  Eigen::VectorXi& descriptor_types =
+      aslam::channels::get_DESCRIPTOR_TYPES_Data(channels_);
+  CHECK_EQ(descriptors.size(), static_cast<size_t>(descriptor_types.size()));
+
+  if (descriptors.size() == 0u) {
+    descriptors.emplace_back(descriptors_new);
+    descriptor_types.resize(1);
+    descriptor_types(0) = descriptor_type;
+  } else {
+    CHECK_LT(index, descriptors.size());
+    descriptors[index] = descriptors_new;
+    descriptor_types(index) = descriptor_type;
   }
-  VisualFrame::DescriptorsT& descriptors =
-      aslam::channels::get_DESCRIPTORS_Data(channels_);
-  descriptors = descriptors_new;
 }
+template void VisualFrame::setDescriptors(
+    const DescriptorsT& descriptors_new, size_t index, int descriptor_type);
+template void VisualFrame::setDescriptors(
+    const Eigen::Map<const DescriptorsT>& descriptors_new, size_t index,
+    int descriptor_type);
+
 void VisualFrame::setTrackIds(const Eigen::VectorXi& track_ids_new) {
   if (!aslam::channels::has_TRACK_IDS_Channel(channels_)) {
     aslam::channels::add_TRACK_IDS_Channel(&channels_);
@@ -283,14 +366,6 @@ void VisualFrame::swapKeypointMeasurementUncertainties(Eigen::VectorXd* uncertai
       aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Data(channels_);
   data.swap(*uncertainties_new);
 }
-void VisualFrame::swapKeypointScales(Eigen::VectorXd* scales_new) {
-  if (!aslam::channels::has_VISUAL_KEYPOINT_SCALES_Channel(channels_)) {
-    aslam::channels::add_VISUAL_KEYPOINT_SCALES_Channel(&channels_);
-  }
-  Eigen::VectorXd& data =
-      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
-  data.swap(*scales_new);
-}
 void VisualFrame::swapKeypointOrientations(Eigen::VectorXd* orientations_new) {
   if (!aslam::channels::has_VISUAL_KEYPOINT_ORIENTATIONS_Channel(channels_)) {
     aslam::channels::add_VISUAL_KEYPOINT_ORIENTATIONS_Channel(&channels_);
@@ -307,16 +382,55 @@ void VisualFrame::swapKeypointScores(Eigen::VectorXd* scores_new) {
       aslam::channels::get_VISUAL_KEYPOINT_SCORES_Data(channels_);
   data.swap(*scores_new);
 }
-void VisualFrame::swapDescriptors(DescriptorsT* descriptors_new) {
+void VisualFrame::swapKeypointScales(Eigen::VectorXd* scales_new) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_SCALES_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_SCALES_Channel(&channels_);
+  }
+  Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
+  data.swap(*scales_new);
+}
+void VisualFrame::swapKeypoint3DPositions(Eigen::Matrix3Xd* positions_new) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_3D_POSITIONS_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_3D_POSITIONS_Channel(&channels_);
+  }
+  Eigen::Matrix3Xd& positions =
+      aslam::channels::get_VISUAL_KEYPOINT_3D_POSITIONS_Data(channels_);
+  positions.swap(*positions_new);
+}
+void VisualFrame::swapKeypointTimeOffsets(Eigen::VectorXi* offsets_new) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_TIME_OFFSETS_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_TIME_OFFSETS_Channel(&channels_);
+  }
+  Eigen::VectorXi& offsets =
+      aslam::channels::get_VISUAL_KEYPOINT_TIME_OFFSETS_Data(channels_);
+  offsets.swap(*offsets_new);
+}
+int VisualFrame::swapDescriptors(
+    DescriptorsT* descriptors_new, size_t index, int descriptor_type) {
+  CHECK_NOTNULL(descriptors_new);
   if (!aslam::channels::has_DESCRIPTORS_Channel(channels_)) {
     aslam::channels::add_DESCRIPTORS_Channel(&channels_);
+    aslam::channels::add_DESCRIPTOR_TYPES_Channel(&channels_);
   }
-  VisualFrame::DescriptorsT& descriptors =
+  std::vector<VisualFrame::DescriptorsT>& descriptors =
       aslam::channels::get_DESCRIPTORS_Data(channels_);
-  descriptors.swap(*descriptors_new);
+  Eigen::VectorXi& descriptor_types =
+      aslam::channels::get_DESCRIPTOR_TYPES_Data(channels_);
+  CHECK_EQ(descriptors.size(), static_cast<size_t>(descriptor_types.size()));
+
+  if (descriptors.size() == 0u) {
+    descriptors.emplace_back();
+    descriptor_types.resize(1);
+  }
+  CHECK(index < descriptors.size());
+  descriptors[index].swap(*descriptors_new);
+  std::swap(descriptor_type, descriptor_types(index));
+  return descriptor_type;
 }
 
 void VisualFrame::swapTrackIds(Eigen::VectorXi* track_ids_new) {
+  CHECK_NOTNULL(track_ids_new);
   if (!aslam::channels::has_TRACK_IDS_Channel(channels_)) {
     aslam::channels::add_TRACK_IDS_Channel(&channels_);
   }
@@ -406,8 +520,8 @@ void VisualFrame::toRawImageCoordinatesVectorized(
   }
 }
 
-size_t VisualFrame::getDescriptorSizeBytes() const {
-  return getDescriptors().rows() * sizeof(DescriptorsT::Scalar);
+size_t VisualFrame::getDescriptorSizeBytes(size_t index) const {
+  return getDescriptors(index).rows() * sizeof(DescriptorsT::Scalar);
 }
 
 Eigen::Matrix3Xd VisualFrame::getNormalizedBearingVectors(
@@ -499,6 +613,421 @@ void VisualFrame::discardUntrackedObservations(
   }
   common::stl_helpers::eraseIndicesFromContainer(
       *discarded_indices, original_count, getTrackIdsMutable());
+}
+
+void VisualFrame::extendKeypointMeasurements(
+    const Eigen::Matrix2Xd& keypoints_new) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_MEASUREMENTS_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_MEASUREMENTS_Channel(&channels_);
+  }
+  Eigen::Matrix2Xd& keypoints =
+      aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENTS_Data(channels_);
+
+  size_t num_keypoints = keypoints.cols();
+  keypoints.conservativeResize(Eigen::NoChange, num_keypoints + keypoints_new.cols());
+  keypoints.block(0, num_keypoints, 2, keypoints_new.cols()) = keypoints_new;
+}
+
+template <typename Derived>
+void extendDataVector(
+    Eigen::Matrix<Derived, Eigen::Dynamic, 1>* data,
+    const Eigen::Matrix<Derived, Eigen::Dynamic, 1>& data_new,
+    size_t num_keypoints, Derived default_value) {
+  const size_t num_data = static_cast<size_t>(data->size() + data_new.size());
+  CHECK_GE(num_keypoints, num_data);
+  const size_t num_padding = num_keypoints - num_data;
+  const size_t original_size = data->size();
+  data->conservativeResize(num_keypoints);
+
+  // Check if we have to pad with the default value in case the previous set
+  // of keypoints are missing this property
+  if (num_padding > 0) {
+    data->segment(original_size, num_padding).setConstant(default_value);
+  }
+
+  data->segment(original_size + num_padding, data_new.size()) = data_new;
+}
+
+void VisualFrame::extendKeypointMeasurementUncertainties(
+    const Eigen::VectorXd& uncertainties_new, double default_value) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Channel(&channels_);
+  }
+  Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Data(channels_);
+  extendDataVector<double>(
+      &data, uncertainties_new, getNumKeypointMeasurements(), default_value);
+}
+
+void VisualFrame::extendKeypointOrientations(
+    const Eigen::VectorXd& orientations_new, double default_value) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_ORIENTATIONS_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_ORIENTATIONS_Channel(&channels_);
+  }
+  Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_ORIENTATIONS_Data(channels_);
+  extendDataVector<double>(
+      &data, orientations_new, getNumKeypointMeasurements(), default_value);
+}
+
+void VisualFrame::extendKeypointScores(
+    const Eigen::VectorXd& scores_new, double default_value) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_SCORES_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_SCORES_Channel(&channels_);
+  }
+  Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCORES_Data(channels_);
+  extendDataVector<double>(
+      &data, scores_new, getNumKeypointMeasurements(), default_value);
+}
+
+void VisualFrame::extendKeypointScales(
+    const Eigen::VectorXd& scales_new, double default_value) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_SCALES_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_SCALES_Channel(&channels_);
+  }
+  Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
+  extendDataVector<double>(
+      &data, scales_new, getNumKeypointMeasurements(), default_value);
+}
+
+void VisualFrame::extendKeypoint3DPositions(
+    const Eigen::Matrix3Xd& positions_new, double default_value) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_3D_POSITIONS_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_3D_POSITIONS_Channel(&channels_);
+  }
+  Eigen::Matrix3Xd& positions =
+      aslam::channels::get_VISUAL_KEYPOINT_3D_POSITIONS_Data(channels_);
+
+  // TODO(smauq): Template this nicely
+  size_t num_keypoints = getNumKeypointMeasurements();
+  const size_t num_positions =
+    static_cast<size_t>(positions.cols() + positions_new.cols());
+  CHECK_GE(num_keypoints, num_positions);
+  const size_t num_padding = num_keypoints - num_positions;
+  const size_t original_size = positions.cols();
+  positions.conservativeResize(Eigen::NoChange, num_keypoints);
+
+  // Check if we have to pad with the default value in case the previous set
+  // of keypoints are missing this property
+  if (num_padding > 0) {
+    positions.block(0, original_size, 3, num_padding).setConstant(default_value);
+  }
+
+  positions.block(0, original_size + num_padding, 3, positions_new.cols()) = positions_new;
+}
+
+void VisualFrame::extendKeypointTimeOffsets(
+    const Eigen::VectorXi& offsets_new, int default_value) {
+  if (!aslam::channels::has_VISUAL_KEYPOINT_TIME_OFFSETS_Channel(channels_)) {
+    aslam::channels::add_VISUAL_KEYPOINT_TIME_OFFSETS_Channel(&channels_);
+  }
+  Eigen::VectorXi& data =
+      aslam::channels::get_VISUAL_KEYPOINT_TIME_OFFSETS_Data(channels_);
+  extendDataVector<int>(
+      &data, offsets_new, getNumKeypointMeasurements(), default_value);
+}
+
+template <typename Derived>
+void VisualFrame::extendDescriptors(
+    const Derived& descriptors_new, int descriptor_type) {
+  if (!aslam::channels::has_DESCRIPTORS_Channel(channels_)) {
+    aslam::channels::add_DESCRIPTORS_Channel(&channels_);
+    aslam::channels::add_DESCRIPTOR_TYPES_Channel(&channels_);
+  }
+  std::vector<VisualFrame::DescriptorsT>& descriptors =
+      aslam::channels::get_DESCRIPTORS_Data(channels_);
+  Eigen::VectorXi& descriptor_types =
+      aslam::channels::get_DESCRIPTOR_TYPES_Data(channels_);
+  CHECK_EQ(descriptors.size(), static_cast<size_t>(descriptor_types.size()));
+
+  descriptors.emplace_back(descriptors_new);
+  const size_t num_descriptor_types = descriptor_types.size();
+  descriptor_types.conservativeResize(num_descriptor_types + 1);
+  descriptor_types(num_descriptor_types) = descriptor_type;
+}
+template void VisualFrame::extendDescriptors(
+    const DescriptorsT& descriptors_new, int descriptor_type);
+template void VisualFrame::extendDescriptors(
+    const Eigen::Map<const DescriptorsT>& descriptors_new, int descriptor_type);
+
+void VisualFrame::extendTrackIds(
+    const Eigen::VectorXi& track_ids_new, int default_value) {
+  if (!aslam::channels::has_TRACK_IDS_Channel(channels_)) {
+    aslam::channels::add_TRACK_IDS_Channel(&channels_);
+  }
+  Eigen::VectorXi& data =
+      aslam::channels::get_TRACK_IDS_Data(channels_);
+  extendDataVector<int>(
+      &data, track_ids_new, getNumKeypointMeasurements(), default_value);
+}
+
+size_t VisualFrame::getNumDescriptors() const {
+  if (!hasDescriptors()) {
+    return 0;
+  }
+
+  size_t num_descriptors = 0;
+  const std::vector<VisualFrame::DescriptorsT>& descriptors =
+      aslam::channels::get_DESCRIPTORS_Data(channels_);
+  for (size_t i = 0; i < descriptors.size(); ++i) {
+    num_descriptors += static_cast<size_t>(descriptors[i].cols());
+  }
+
+  return num_descriptors;
+}
+
+void VisualFrame::serializeDescriptorsToString(std::string* descriptors_string) const {
+  CHECK(aslam::channels::has_DESCRIPTORS_Channel(channels_));
+  aslam::channels::serialize_DESCRIPTORS_Channel(channels_, descriptors_string);
+}
+
+void VisualFrame::deserializeDescriptorsFromString(const std::string& descriptors_string) {
+  if (!aslam::channels::has_DESCRIPTORS_Channel(channels_)) {
+    aslam::channels::add_DESCRIPTORS_Channel(&channels_);
+  }
+  aslam::channels::deserialize_DESCRIPTORS_Channel(channels_, descriptors_string);
+}
+
+bool VisualFrame::hasDescriptorType(int descriptor_type) const {
+  const Eigen::VectorXi& descriptor_types =
+      aslam::channels::get_DESCRIPTOR_TYPES_Data(channels_);
+  for (int block = 0; block < descriptor_types.size(); ++block) {
+    if (descriptor_types.coeff(block) == descriptor_type) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void VisualFrame::setDescriptorTypes(const Eigen::VectorXi& descriptor_types) {
+  const std::vector<VisualFrame::DescriptorsT>& descriptors =
+      aslam::channels::get_DESCRIPTORS_Data(channels_);
+  CHECK_EQ(descriptors.size(), static_cast<size_t>(descriptor_types.size()));
+
+  if (!aslam::channels::has_DESCRIPTOR_TYPES_Channel(channels_)) {
+    aslam::channels::add_DESCRIPTOR_TYPES_Channel(&channels_);
+  }
+  Eigen::VectorXi& data =
+      aslam::channels::get_DESCRIPTOR_TYPES_Data(channels_);
+  data = descriptor_types;
+}
+
+const Eigen::VectorXi& VisualFrame::getDescriptorTypes() const {
+  return aslam::channels::get_DESCRIPTOR_TYPES_Data(channels_);
+}
+
+int VisualFrame::getDescriptorType(size_t index) const {
+  std::vector<VisualFrame::DescriptorsT>& descriptors =
+      aslam::channels::get_DESCRIPTORS_Data(channels_);
+  size_t block = getDescriptorBlockForIndex(descriptors, &index);
+  return getDescriptorBlockType(block);
+}
+
+int VisualFrame::getDescriptorBlockType(size_t block) const {
+  Eigen::VectorXi& descriptor_types =
+      aslam::channels::get_DESCRIPTOR_TYPES_Data(channels_);
+  CHECK_LT(block, static_cast<size_t>(descriptor_types.size()));
+  return descriptor_types.coeff(block);
+}
+
+size_t VisualFrame::getDescriptorTypeBlock(int descriptor_type) const {
+  const Eigen::VectorXi& descriptor_types =
+      aslam::channels::get_DESCRIPTOR_TYPES_Data(channels_);
+  for (int block = 0; block < descriptor_types.size(); ++block) {
+    if (descriptor_types.coeff(block) == descriptor_type) {
+      return block;
+    }
+  }
+  LOG(FATAL)
+      << "Descriptor type " << descriptor_type << " does not exist in frame "
+      << " id " << id_ << " at timestamp " << timestamp_nanoseconds_ << " ns.";
+}
+
+size_t VisualFrame::getNumKeypointMeasurementsOfType(int descriptor_type) const {
+  const std::vector<VisualFrame::DescriptorsT>& descriptors =
+      aslam::channels::get_DESCRIPTORS_Data(channels_);
+  if (!hasDescriptorType(descriptor_type)) {
+    return 0u;
+  }
+  const size_t block = getDescriptorTypeBlock(descriptor_type);
+  CHECK_LT(block, descriptors.size());
+  return descriptors[block].cols();
+}
+
+void VisualFrame::getDescriptorBlockTypeStartAndSize(
+  int descriptor_type, size_t *start, size_t *size) const {
+  CHECK_NOTNULL(start);
+  CHECK_NOTNULL(size);
+
+  const std::vector<VisualFrame::DescriptorsT>& descriptors =
+      aslam::channels::get_DESCRIPTORS_Data(channels_);
+  const size_t block = getDescriptorTypeBlock(descriptor_type);
+
+  *start = 0;
+  for (size_t i = 0u; i < block; i++) {
+    *start += descriptors[i].cols();
+  }
+  *size = descriptors[block].cols();
+}
+
+const Eigen::Block<const Eigen::Matrix2Xd> VisualFrame::getKeypointMeasurementsOfType(
+    int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  const Eigen::Matrix2Xd& keypoints =
+      aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENTS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(keypoints.cols()));
+  return keypoints.block(0, start, 2, size);
+}
+const Eigen::VectorBlock<const Eigen::VectorXd>
+VisualFrame::getKeypointMeasurementUncertaintiesOfType(int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.segment(start, size);
+}
+const Eigen::VectorBlock<const Eigen::VectorXd>
+VisualFrame::getKeypointOrientationsOfType(int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_ORIENTATIONS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.segment(start, size);
+}
+const Eigen::VectorBlock<const Eigen::VectorXd> VisualFrame::getKeypointScoresOfType(
+    int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCORES_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.segment(start, size);
+}
+const Eigen::VectorBlock<const Eigen::VectorXd> VisualFrame::getKeypointScalesOfType(
+    int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.segment(start, size);
+}
+const Eigen::Block<const Eigen::Matrix3Xd> VisualFrame::getKeypoint3DPositionsOfType(
+    int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  const Eigen::Matrix3Xd& positions =
+      aslam::channels::get_VISUAL_KEYPOINT_3D_POSITIONS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(positions.cols()));
+  return positions.block(0, start, 3, size);
+}
+const Eigen::VectorBlock<const Eigen::VectorXi> VisualFrame::getKeypointTimeOffsetsOfType(
+    int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  const Eigen::VectorXi& data =
+      aslam::channels::get_VISUAL_KEYPOINT_TIME_OFFSETS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.segment(start, size);
+}
+const VisualFrame::DescriptorsT& VisualFrame::getDescriptorsOfType(int descriptor_type) const {
+  const size_t block = getDescriptorTypeBlock(descriptor_type);
+  return getDescriptors(block);
+}
+const Eigen::VectorBlock<const Eigen::VectorXi> VisualFrame::getTrackIdsOfType(
+    int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  const Eigen::VectorXi& data =
+      aslam::channels::get_TRACK_IDS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.segment(start, size);
+}
+
+const Eigen::Block<const Eigen::Matrix2Xd, 2, 1> VisualFrame::getKeypointMeasurementOfType(
+    size_t index, int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  CHECK_LT(index, size);
+  const Eigen::Matrix2Xd& keypoints =
+      aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENTS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(keypoints.cols()));
+  return keypoints.block<2, 1>(0, start + index);
+}
+double VisualFrame::getKeypointMeasurementUncertaintyOfType(
+    size_t index, int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  CHECK_LT(index, size);
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_MEASUREMENT_UNCERTAINTIES_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.coeff(start + index);
+}
+double VisualFrame::getKeypointOrientationOfType(size_t index, int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  CHECK_LT(index, size);
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_ORIENTATIONS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.coeff(start + index);
+}
+double VisualFrame::getKeypointScoreOfType(size_t index, int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  CHECK_LT(index, size);
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCORES_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.coeff(start + index);
+}
+double VisualFrame::getKeypointScaleOfType(size_t index, int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  CHECK_LT(index, size);
+  const Eigen::VectorXd& data =
+      aslam::channels::get_VISUAL_KEYPOINT_SCALES_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.coeff(start + index);
+}
+const Eigen::Block<const Eigen::Matrix3Xd, 3, 1> VisualFrame::getKeypoint3DPositionOfType(
+    size_t index, int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  CHECK_LT(index, size);
+  const Eigen::Matrix3Xd& positions =
+      aslam::channels::get_VISUAL_KEYPOINT_3D_POSITIONS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(positions.cols()));
+  return positions.block<3, 1>(0, start + index);
+}
+int VisualFrame::getKeypointTimeOffsetOfType(size_t index, int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  CHECK_LT(index, size);
+  const Eigen::VectorXi& data =
+      aslam::channels::get_VISUAL_KEYPOINT_TIME_OFFSETS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(data.size()));
+  return data.coeff(start + index);
+}
+int VisualFrame::getTrackIdOfType(size_t index, int descriptor_type) const {
+  size_t start, size;
+  getDescriptorBlockTypeStartAndSize(descriptor_type, &start, &size);
+  CHECK_LT(index, size);
+  const Eigen::VectorXi& track_ids =
+      aslam::channels::get_TRACK_IDS_Data(channels_);
+  CHECK_LE(start + size, static_cast<size_t>(track_ids.size()));
+  return track_ids.coeff(start + index);
+}
+
+size_t VisualFrame::getDescriptorTypeSizeBytes(int descriptor_type) const {
+  const size_t block = getDescriptorTypeBlock(descriptor_type);
+  return getDescriptors(block).rows() * sizeof(DescriptorsT::Scalar);
 }
 
 }  // namespace aslam

--- a/aslam_cv_frames/test/test-visual-frame.cc
+++ b/aslam_cv_frames/test/test-visual-frame.cc
@@ -48,24 +48,51 @@ TEST(Frame, DeathOnGetMutableUnsetData) {
 
 TEST(Frame, SetGetDescriptors) {
   aslam::VisualFrame frame;
-  aslam::VisualFrame::DescriptorsT data;
-  data.resize(48, 10);
+  aslam::VisualFrame::DescriptorsT data(48, 10);
   data.setRandom();
   frame.setDescriptors(data);
-  const aslam::VisualFrame::DescriptorsT& data_2 =
-      frame.getDescriptors();
-  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_2, 0));
-  EXPECT_EQ(&data_2, frame.getDescriptorsMutable());
-  for (int i = 0; i < data.cols(); ++i) {
-    const unsigned char* data_ptr = frame.getDescriptor(i);
-    EXPECT_EQ(&data_2.coeffRef(0, i), data_ptr);
+  {
+    const aslam::VisualFrame::DescriptorsT& data_2 =
+        frame.getDescriptors();
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_2, 0));
+    EXPECT_EQ(&data_2, frame.getDescriptorsMutable());
+    for (int i = 0; i < data.cols(); ++i) {
+      const unsigned char* data_ptr = frame.getDescriptor(i);
+      EXPECT_EQ(&data_2.coeffRef(0, i), data_ptr);
+    }
+  }
+
+  // Test extending
+  aslam::VisualFrame::DescriptorsT data_ext(64, 12);
+  data_ext.setRandom();
+  frame.extendDescriptors(data_ext, 1);
+  {
+    const aslam::VisualFrame::DescriptorsT& data_2 =
+        frame.getDescriptors(0);
+    const aslam::VisualFrame::DescriptorsT& data_3 =
+        frame.getDescriptors(1);
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_2, 0));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_3, 0));
+    EXPECT_EQ(&data_2, frame.getDescriptorsMutable(0));
+    EXPECT_EQ(&data_3, frame.getDescriptorsMutable(1));
+    for (int i = 0; i < data.cols(); ++i) {
+      const unsigned char* data_ptr = frame.getDescriptor(i);
+      EXPECT_EQ(&data_2.coeffRef(0, i), data_ptr);
+    }
+    for (int i = 0; i < data_ext.cols(); ++i) {
+      const size_t index = data.cols() + i;
+      const unsigned char* data_ptr = frame.getDescriptor(index);
+      EXPECT_EQ(&data_3.coeffRef(0, i), data_ptr);
+    }
+
+    EXPECT_EQ(data_2, frame.getDescriptorsOfType(0));
+    EXPECT_EQ(data_3, frame.getDescriptorsOfType(1));
   }
 }
 
 TEST(Frame, SetGetKeypointMeasurements) {
   aslam::VisualFrame frame;
-  Eigen::Matrix2Xd data;
-  data.resize(Eigen::NoChange, 10);
+  Eigen::Matrix2Xd data(2, 10);
   data.setRandom();
   frame.setKeypointMeasurements(data);
   const Eigen::Matrix2Xd& data_2 = frame.getKeypointMeasurements();
@@ -76,12 +103,52 @@ TEST(Frame, SetGetKeypointMeasurements) {
     const Eigen::Vector2d& should = data.block<2, 1>(0, i);
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(should, ref, 1e-6));
   }
+
+  // Test extending
+  Eigen::Matrix2Xd data_ext(2, 20);
+  data_ext.setRandom();
+  frame.extendKeypointMeasurements(data_ext);
+  const Eigen::Matrix2Xd& data_3 = frame.getKeypointMeasurements();
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_3.block(0, 0, 2, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_3.block(0, 10, 2, 20), 1e-6));
+
+  // Some descriptors are necessary in the frame since the keypoint type
+  // is defined by the descriptor type
+  aslam::VisualFrame::DescriptorsT desc_1(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_2(8, 20);
+  desc_1.setRandom();
+  desc_2.setRandom();
+  frame.setDescriptors(desc_1, 0);
+  frame.extendDescriptors(desc_2, 1);
+
+  const Eigen::Block<const Eigen::Matrix2Xd> data_subset_1 =
+      frame.getKeypointMeasurementsOfType(0);
+  const Eigen::Block<const Eigen::Matrix2Xd> data_subset_2 =
+      frame.getKeypointMeasurementsOfType(1);
+
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_subset_1, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_subset_2, 1e-6));
+
+  for (int i = 0; i < 10; i++) {
+    const Eigen::Vector2d& ref = frame.getKeypointMeasurementOfType(i, 0);
+    const Eigen::Vector2d& should = data.block<2, 1>(0, i);
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(should, ref, 1e-6));
+  }
+
+  for (int i = 0; i < 20; i++) {
+    const Eigen::Vector2d& ref = frame.getKeypointMeasurementOfType(i, 1);
+    const Eigen::Vector2d& should = data_ext.block<2, 1>(0, i);
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(should, ref, 1e-6));
+  }
+
+  // Check memory addresses again and that no copy operations happened
+  CHECK_EQ(&(data_3.coeff(0,0)), &(data_subset_1.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(0,10)), &(data_subset_2.coeff(0,0)));
 }
 
 TEST(Frame, SetGetKeypointMeasurementUncertainties) {
   aslam::VisualFrame frame;
-  Eigen::VectorXd data;
-  data.resize(10);
+  Eigen::VectorXd data(10);
   data.setRandom();
   frame.setKeypointMeasurementUncertainties(data);
   const Eigen::VectorXd& data_2 = frame.getKeypointMeasurementUncertainties();
@@ -91,12 +158,71 @@ TEST(Frame, SetGetKeypointMeasurementUncertainties) {
     double ref = frame.getKeypointMeasurementUncertainty(i);
     EXPECT_NEAR(data(i), ref, 1e-6);
   }
+
+  // Test extending as well as the default padding
+  Eigen::Matrix2Xd keypoints(2, 40);
+  keypoints.setRandom();
+  frame.setKeypointMeasurements(keypoints);
+
+  Eigen::VectorXd data_ext(20);
+  data_ext.setRandom();
+  frame.extendKeypointMeasurementUncertainties(data_ext, 0.0);
+  const Eigen::VectorXd& data_3 = frame.getKeypointMeasurementUncertainties();
+  EXPECT_EQ(data_3.size(), keypoints.cols());
+
+  Eigen::VectorXd data_zero(10);
+  data_zero.setConstant(0.0);
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_3.segment(0, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_3.segment(10, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_3.segment(20, 20), 1e-6));
+
+  // Some descriptors are necessary in the frame since the keypoint type
+  // is defined by the descriptor type
+  aslam::VisualFrame::DescriptorsT desc_1(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_2(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_3(8, 20);
+  desc_1.setRandom();
+  desc_2.setRandom();
+  desc_3.setRandom();
+  frame.setDescriptors(desc_1, 0);
+  frame.extendDescriptors(desc_2, 1);
+  frame.extendDescriptors(desc_3, 2);
+
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_1 =
+      frame.getKeypointMeasurementUncertaintiesOfType(0);
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_2 =
+      frame.getKeypointMeasurementUncertaintiesOfType(1);
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_3 =
+      frame.getKeypointMeasurementUncertaintiesOfType(2);
+
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_subset_1, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_subset_2, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_subset_3, 1e-6));
+
+  for (int i = 0; i < 10; i++) {
+    const double ref = frame.getKeypointMeasurementUncertaintyOfType(i, 0);
+    EXPECT_EQ(data(i), ref);
+  }
+
+  for (int i = 0; i < 10; i++) {
+    const double ref = frame.getKeypointMeasurementUncertaintyOfType(i, 1);
+    EXPECT_EQ(data_zero(i), ref);
+  }
+
+  for (int i = 0; i < 20; i++) {
+    const double ref = frame.getKeypointMeasurementUncertaintyOfType(i, 2);
+    EXPECT_EQ(data_ext(i), ref);
+  }
+
+  // Check memory addresses again and that no copy operations happened
+  CHECK_EQ(&(data_3.coeff(0)), &(data_subset_1.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(10)), &(data_subset_2.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(20)), &(data_subset_3.coeff(0,0)));
 }
 
 TEST(Frame, SetGetKeypointOrientations) {
   aslam::VisualFrame frame;
-  Eigen::VectorXd data;
-  data.resize(10);
+  Eigen::VectorXd data(10);
   data.setRandom();
   frame.setKeypointOrientations(data);
   const Eigen::VectorXd& data_2 = frame.getKeypointOrientations();
@@ -106,6 +232,66 @@ TEST(Frame, SetGetKeypointOrientations) {
     double ref = frame.getKeypointOrientation(i);
     EXPECT_NEAR(data(i), ref, 1e-6);
   }
+
+  // Test extending as well as the default padding
+  Eigen::Matrix2Xd keypoints(2, 40);
+  keypoints.setRandom();
+  frame.setKeypointMeasurements(keypoints);
+
+  Eigen::VectorXd data_ext(20);
+  data_ext.setRandom();
+  frame.extendKeypointOrientations(data_ext, 0.0);
+  const Eigen::VectorXd& data_3 = frame.getKeypointOrientations();
+  EXPECT_EQ(data_3.size(), keypoints.cols());
+
+  Eigen::VectorXd data_zero(10);
+  data_zero.setConstant(0.0);
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_3.segment(0, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_3.segment(10, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_3.segment(20, 20), 1e-6));
+
+  // Some descriptors are necessary in the frame since the keypoint type
+  // is defined by the descriptor type
+  aslam::VisualFrame::DescriptorsT desc_1(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_2(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_3(8, 20);
+  desc_1.setRandom();
+  desc_2.setRandom();
+  desc_3.setRandom();
+  frame.setDescriptors(desc_1, 0);
+  frame.extendDescriptors(desc_2, 1);
+  frame.extendDescriptors(desc_3, 2);
+
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_1 =
+      frame.getKeypointOrientationsOfType(0);
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_2 =
+      frame.getKeypointOrientationsOfType(1);
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_3 =
+      frame.getKeypointOrientationsOfType(2);
+
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_subset_1, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_subset_2, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_subset_3, 1e-6));
+
+  for (int i = 0; i < 10; i++) {
+    const double ref = frame.getKeypointOrientationOfType(i, 0);
+    EXPECT_EQ(data(i), ref);
+  }
+
+  for (int i = 0; i < 10; i++) {
+    const double ref = frame.getKeypointOrientationOfType(i, 1);
+    EXPECT_EQ(data_zero(i), ref);
+  }
+
+  for (int i = 0; i < 20; i++) {
+    const double ref = frame.getKeypointOrientationOfType(i, 2);
+    EXPECT_EQ(data_ext(i), ref);
+  }
+
+  // Check memory addresses again and that no copy operations happened
+  CHECK_EQ(&(data_3.coeff(0)), &(data_subset_1.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(10)), &(data_subset_2.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(20)), &(data_subset_3.coeff(0,0)));
 }
 
 TEST(Frame, SetGetKeypointScales) {
@@ -121,6 +307,216 @@ TEST(Frame, SetGetKeypointScales) {
     double ref = frame.getKeypointScale(i);
     EXPECT_NEAR(data(i), ref, 1e-6);
   }
+
+  // Test extending as well as the default padding
+  Eigen::Matrix2Xd keypoints(2, 40);
+  keypoints.setRandom();
+  frame.setKeypointMeasurements(keypoints);
+
+  Eigen::VectorXd data_ext(20);
+  data_ext.setRandom();
+  frame.extendKeypointScales(data_ext, 0.0);
+  const Eigen::VectorXd& data_3 = frame.getKeypointScales();
+  EXPECT_EQ(data_3.size(), keypoints.cols());
+
+  Eigen::VectorXd data_zero(10);
+  data_zero.setConstant(0.0);
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_3.segment(0, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_3.segment(10, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_3.segment(20, 20), 1e-6));
+
+  // Some descriptors are necessary in the frame since the keypoint type
+  // is defined by the descriptor type
+  aslam::VisualFrame::DescriptorsT desc_1(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_2(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_3(8, 20);
+  desc_1.setRandom();
+  desc_2.setRandom();
+  desc_3.setRandom();
+  frame.setDescriptors(desc_1, 0);
+  frame.extendDescriptors(desc_2, 1);
+  frame.extendDescriptors(desc_3, 2);
+
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_1 =
+      frame.getKeypointScalesOfType(0);
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_2 =
+      frame.getKeypointScalesOfType(1);
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_3 =
+      frame.getKeypointScalesOfType(2);
+
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_subset_1, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_subset_2, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_subset_3, 1e-6));
+
+  for (int i = 0; i < 10; i++) {
+    const double ref = frame.getKeypointScaleOfType(i, 0);
+    EXPECT_EQ(data(i), ref);
+  }
+
+  for (int i = 0; i < 10; i++) {
+    const double ref = frame.getKeypointScaleOfType(i, 1);
+    EXPECT_EQ(data_zero(i), ref);
+  }
+
+  for (int i = 0; i < 20; i++) {
+    const double ref = frame.getKeypointScaleOfType(i, 2);
+    EXPECT_EQ(data_ext(i), ref);
+  }
+
+  // Check memory addresses again and that no copy operations happened
+  CHECK_EQ(&(data_3.coeff(0)), &(data_subset_1.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(10)), &(data_subset_2.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(20)), &(data_subset_3.coeff(0,0)));
+}
+
+TEST(Frame, SetGetKeypointScores) {
+  aslam::VisualFrame frame;
+  Eigen::VectorXd data;
+  data.resize(10);
+  data.setRandom();
+  frame.setKeypointScores(data);
+  const Eigen::VectorXd& data_2 = frame.getKeypointScores();
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_2, 1e-6));
+  EXPECT_EQ(&data_2, frame.getKeypointScoresMutable());
+  for (int i = 0; i < data.cols(); ++i) {
+    double ref = frame.getKeypointScore(i);
+    EXPECT_NEAR(data(i), ref, 1e-6);
+  }
+
+  // Test extending as well as the default padding
+  Eigen::Matrix2Xd keypoints(2, 40);
+  keypoints.setRandom();
+  frame.setKeypointMeasurements(keypoints);
+
+  Eigen::VectorXd data_ext(20);
+  data_ext.setRandom();
+  frame.extendKeypointScores(data_ext, 0.0);
+  const Eigen::VectorXd& data_3 = frame.getKeypointScores();
+  EXPECT_EQ(data_3.size(), keypoints.cols());
+
+  Eigen::VectorXd data_zero(10);
+  data_zero.setConstant(0.0);
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_3.segment(0, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_3.segment(10, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_3.segment(20, 20), 1e-6));
+
+  // Some descriptors are necessary in the frame since the keypoint type
+  // is defined by the descriptor type
+  aslam::VisualFrame::DescriptorsT desc_1(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_2(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_3(8, 20);
+  desc_1.setRandom();
+  desc_2.setRandom();
+  desc_3.setRandom();
+  frame.setDescriptors(desc_1, 0);
+  frame.extendDescriptors(desc_2, 1);
+  frame.extendDescriptors(desc_3, 2);
+
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_1 =
+      frame.getKeypointScoresOfType(0);
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_2 =
+      frame.getKeypointScoresOfType(1);
+  const Eigen::VectorBlock<const Eigen::VectorXd> data_subset_3 =
+      frame.getKeypointScoresOfType(2);
+
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_subset_1, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_subset_2, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_subset_3, 1e-6));
+
+  for (int i = 0; i < 10; i++) {
+    const double ref = frame.getKeypointScoreOfType(i, 0);
+    EXPECT_EQ(data(i), ref);
+  }
+
+  for (int i = 0; i < 10; i++) {
+    const double ref = frame.getKeypointScoreOfType(i, 1);
+    EXPECT_EQ(data_zero(i), ref);
+  }
+
+  for (int i = 0; i < 20; i++) {
+    const double ref = frame.getKeypointScoreOfType(i, 2);
+    EXPECT_EQ(data_ext(i), ref);
+  }
+
+  // Check memory addresses again and that no copy operations happened
+  CHECK_EQ(&(data_3.coeff(0)), &(data_subset_1.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(10)), &(data_subset_2.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(20)), &(data_subset_3.coeff(0,0)));
+}
+
+TEST(Frame, SetGetTrackIds) {
+  aslam::VisualFrame frame;
+  Eigen::VectorXi data;
+  data.resize(10);
+  data.setRandom();
+  frame.setTrackIds(data);
+  const Eigen::VectorXi& data_2 = frame.getTrackIds();
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_2, 1e-6));
+  EXPECT_EQ(&data_2, frame.getTrackIdsMutable());
+  for (int i = 0; i < data.cols(); ++i) {
+    int ref = frame.getTrackId(i);
+    EXPECT_EQ(data(i), ref);
+  }
+
+  // Test extending as well as the default padding
+  Eigen::Matrix2Xd keypoints(2, 40);
+  keypoints.setRandom();
+  frame.setKeypointMeasurements(keypoints);
+
+  Eigen::VectorXi data_ext(20);
+  data_ext.setRandom();
+  frame.extendTrackIds(data_ext, -1);
+  const Eigen::VectorXi& data_3 = frame.getTrackIds();
+  EXPECT_EQ(data_3.size(), keypoints.cols());
+
+  Eigen::VectorXi data_zero(10);
+  data_zero.setConstant(-1);
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_3.segment(0, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_3.segment(10, 10), 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_3.segment(20, 20), 1e-6));
+
+  // Some descriptors are necessary in the frame since the keypoint type
+  // is defined by the descriptor type
+  aslam::VisualFrame::DescriptorsT desc_1(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_2(8, 10);
+  aslam::VisualFrame::DescriptorsT desc_3(8, 20);
+  desc_1.setRandom();
+  desc_2.setRandom();
+  desc_3.setRandom();
+  frame.setDescriptors(desc_1, 0);
+  frame.extendDescriptors(desc_2, 1);
+  frame.extendDescriptors(desc_3, 2);
+
+  const Eigen::VectorBlock<const Eigen::VectorXi> data_subset_1 =
+      frame.getTrackIdsOfType(0);
+  const Eigen::VectorBlock<const Eigen::VectorXi> data_subset_2 =
+      frame.getTrackIdsOfType(1);
+  const Eigen::VectorBlock<const Eigen::VectorXi> data_subset_3 =
+      frame.getTrackIdsOfType(2);
+
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data, data_subset_1, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_zero, data_subset_2, 1e-6));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(data_ext, data_subset_3, 1e-6));
+
+  for (int i = 0; i < 10; i++) {
+    const int ref = frame.getTrackIdOfType(i, 0);
+    EXPECT_EQ(data(i), ref);
+  }
+
+  for (int i = 0; i < 10; i++) {
+    const int ref = frame.getTrackIdOfType(i, 1);
+    EXPECT_EQ(data_zero(i), ref);
+  }
+
+  for (int i = 0; i < 20; i++) {
+    const int ref = frame.getTrackIdOfType(i, 2);
+    EXPECT_EQ(data_ext(i), ref);
+  }
+
+  // Check memory addresses again and that no copy operations happened
+  CHECK_EQ(&(data_3.coeff(0)), &(data_subset_1.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(10)), &(data_subset_2.coeff(0,0)));
+  CHECK_EQ(&(data_3.coeff(20)), &(data_subset_3.coeff(0,0)));
 }
 
 TEST(Frame, NamedChannel) {

--- a/aslam_cv_geometric_vision/src/match-outlier-rejection-twopt.cc
+++ b/aslam_cv_geometric_vision/src/match-outlier-rejection-twopt.cc
@@ -21,7 +21,7 @@ bool rejectOutlierFeatureMatchesTranslationRotationSAC(
     bool fix_random_seed, double ransac_threshold, size_t ransac_max_iterations,
     aslam::FrameToFrameMatchesWithScore* inlier_matches_kp1_k,
     aslam::FrameToFrameMatchesWithScore* outlier_matches_kp1_k) {
-    
+
   BearingVectors bearing_vectors_kp1;
   BearingVectors bearing_vectors_k;
 

--- a/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
+++ b/aslam_cv_matcher/include/aslam/matcher/gyro-two-frame-matcher.h
@@ -53,6 +53,7 @@ class GyroTwoFrameMatcher {
   GyroTwoFrameMatcher(const Quaternion& q_Ckp1_Ck,
                       const VisualFrame& frame_kp1,
                       const VisualFrame& frame_k,
+                      const int descriptor_type,
                       const uint32_t image_height,
                       const Eigen::Matrix2Xd& predicted_keypoint_positions_kp1,
                       const std::vector<unsigned char>& prediction_success,
@@ -132,6 +133,9 @@ class GyroTwoFrameMatcher {
   // Rotation matrix that describes the camera rotation between the
   // two frames that are matched.
   const Quaternion& q_Ckp1_Ck_;
+  // Descriptor type to match, used to support multiple different types
+  // Of descriptors to co-exist in the aslam visual frame
+  const int descriptor_type_;
   // Predicted locations of the keypoints in frame k
   // in frame (k+1) based on camera rotation.
   const Eigen::Matrix2Xd& predicted_keypoint_positions_kp1_;

--- a/aslam_cv_matcher/include/aslam/matcher/match-helpers.h
+++ b/aslam_cv_matcher/include/aslam/matcher/match-helpers.h
@@ -80,7 +80,8 @@ void getBearingVectorsFromMatches(
 void predictKeypointsByRotation(const VisualFrame& frame_k,
                                 const aslam::Quaternion& q_Ckp1_Ck,
                                 Eigen::Matrix2Xd* predicted_keypoints_kp1,
-                                std::vector<unsigned char>* prediction_success);
+                                std::vector<unsigned char>* prediction_success,
+                                int descriptor_type = 0);
 void predictKeypointsByRotation(const aslam::Camera& camera,
                                 const Eigen::Matrix2Xd keypoints_k,
                                 const aslam::Quaternion& q_Ckp1_Ck,

--- a/aslam_cv_matcher/include/aslam/matcher/match.h
+++ b/aslam_cv_matcher/include/aslam/matcher/match.h
@@ -75,7 +75,6 @@ struct MatchWithScore {
            (this->score == other.score);
   }
 
- protected:
   /// \brief Get the index into list A.
   int getIndexApple() const {
     return correspondence[0];

--- a/aslam_cv_matcher/src/match-helpers.cc
+++ b/aslam_cv_matcher/src/match-helpers.cc
@@ -222,7 +222,8 @@ void getBearingVectorsFromMatches(
 void predictKeypointsByRotation(const VisualFrame& frame_k,
                                 const aslam::Quaternion& q_Ckp1_Ck,
                                 Eigen::Matrix2Xd* predicted_keypoints_kp1,
-                                std::vector<unsigned char>* prediction_success) {
+                                std::vector<unsigned char>* prediction_success,
+                                int descriptor_type) {
   CHECK_NOTNULL(predicted_keypoints_kp1);
   CHECK_NOTNULL(prediction_success)->clear();
   CHECK(frame_k.hasKeypointMeasurements());
@@ -230,7 +231,7 @@ void predictKeypointsByRotation(const VisualFrame& frame_k,
   const aslam::Camera& camera =
       *CHECK_NOTNULL(frame_k.getCameraGeometry().get());
 
-  predictKeypointsByRotation(camera, frame_k.getKeypointMeasurements(),
+  predictKeypointsByRotation(camera, frame_k.getKeypointMeasurementsOfType(descriptor_type),
                              q_Ckp1_Ck, predicted_keypoints_kp1,
                              prediction_success);
 }

--- a/aslam_cv_matcher/test/test-matcher-non-exclusive.cc
+++ b/aslam_cv_matcher/test/test-matcher-non-exclusive.cc
@@ -53,9 +53,9 @@ TEST_F(MatcherTest, MatchIdentity) {
   Eigen::Matrix2Xd apple_keypoints = Eigen::Matrix2Xd::Ones(2, 1);
   Eigen::Matrix2Xd banana_keypoints = Eigen::Matrix2Xd::Ones(2, 1);
 
-  Eigen::Matrix<unsigned char, 48, 1> apple_descriptors =
+  aslam::VisualFrame::DescriptorsT apple_descriptors =
       Eigen::Matrix<unsigned char, 48, 1>::Zero();
-  Eigen::Matrix<unsigned char, 48, 1> banana_descriptors =
+  aslam::VisualFrame::DescriptorsT banana_descriptors =
       Eigen::Matrix<unsigned char, 48, 1>::Zero();
 
   apple_frame_->setKeypointMeasurements(apple_keypoints);
@@ -107,9 +107,9 @@ TEST_F(MatcherTest, MatchRotation) {
   Eigen::Matrix2Xd banana_keypoints = Eigen::Matrix2Xd::Zero(2, 1);
   banana_keypoints.col(0) = banana_keypoint;
 
-  Eigen::Matrix<unsigned char, 48, 1> apple_descriptors =
+  aslam::VisualFrame::DescriptorsT apple_descriptors =
       Eigen::Matrix<unsigned char, 48, 1>::Zero();
-  Eigen::Matrix<unsigned char, 48, 1> banana_descriptors =
+  aslam::VisualFrame::DescriptorsT banana_descriptors =
       Eigen::Matrix<unsigned char, 48, 1>::Zero();
 
   apple_frame_->setKeypointMeasurements(apple_keypoints);
@@ -138,9 +138,9 @@ TEST_F(MatcherTest, TestImageSpaceBorderOut) {
   Eigen::Matrix2Xd banana_keypoints = Eigen::Matrix2Xd::Constant(2, 1, 20.0);
   banana_keypoints(0, 0) = 20.0 + image_space_distance_threshold_;
 
-  Eigen::Matrix<unsigned char, 48, 1> apple_descriptors =
+  aslam::VisualFrame::DescriptorsT apple_descriptors =
       Eigen::Matrix<unsigned char, 48, 1>::Zero();
-  Eigen::Matrix<unsigned char, 48, 1> banana_descriptors =
+  aslam::VisualFrame::DescriptorsT banana_descriptors =
       Eigen::Matrix<unsigned char, 48, 1>::Zero();
 
   apple_frame_->setKeypointMeasurements(apple_keypoints);
@@ -167,9 +167,9 @@ TEST_F(MatcherTest, TestImageSpaceBorderIn) {
   Eigen::Matrix2Xd banana_keypoints = Eigen::Matrix2Xd::Constant(2, 1, 20.0);
   banana_keypoints(0, 0) = 20.0 + image_space_distance_threshold_ - 1e-12;
 
-  Eigen::Matrix<unsigned char, 48, 1> apple_descriptors =
+  aslam::VisualFrame::DescriptorsT apple_descriptors =
       Eigen::Matrix<unsigned char, 48, 1>::Zero();
-  Eigen::Matrix<unsigned char, 48, 1> banana_descriptors =
+  aslam::VisualFrame::DescriptorsT banana_descriptors =
       Eigen::Matrix<unsigned char, 48, 1>::Zero();
 
   apple_frame_->setKeypointMeasurements(apple_keypoints);
@@ -240,11 +240,11 @@ TEST_F(MatcherTest, TestComplex) {
   }
   CHECK_EQ(banana_idx, 5u);
 
-  Eigen::Matrix<unsigned char, 48, 5> apple_descriptors =
+  aslam::VisualFrame::DescriptorsT apple_descriptors =
       Eigen::Matrix<unsigned char, 48, 5>::Zero();
   apple_descriptors(0, 1) = 1;
 
-  Eigen::Matrix<unsigned char, 48, 5> banana_descriptors =
+  aslam::VisualFrame::DescriptorsT banana_descriptors =
       Eigen::Matrix<unsigned char, 48, 5>::Zero();
 
   apple_frame_->setKeypointMeasurements(apple_keypoints);

--- a/aslam_cv_pipeline/src/visual-pipeline-brisk.cc
+++ b/aslam_cv_pipeline/src/visual-pipeline-brisk.cc
@@ -79,9 +79,9 @@ void BriskVisualPipeline::processFrameImpl(const cv::Mat& image, VisualFrame* fr
   CHECK(descriptors.isContinuous());
   frame->setDescriptors(
       // Switch cols/rows as Eigen is col-major and cv::Mat is row-major
-      Eigen::Map<VisualFrame::DescriptorsT>(descriptors.data,
-                                            descriptors.cols,
-                                            descriptors.rows)
+      Eigen::Map<const VisualFrame::DescriptorsT>(descriptors.data,
+                                                  descriptors.cols,
+                                                  descriptors.rows)
   );
 
   // The keypoint uncertainty is set to a constant value.

--- a/aslam_cv_pipeline/src/visual-pipeline-freak.cc
+++ b/aslam_cv_pipeline/src/visual-pipeline-freak.cc
@@ -82,9 +82,9 @@ void FreakVisualPipeline::processFrameImpl(const cv::Mat& image, VisualFrame* fr
   CHECK(descriptors.isContinuous());
   frame->setDescriptors(
       // Switch cols/rows as Eigen is col-major and cv::Mat is row-major
-      Eigen::Map<VisualFrame::DescriptorsT>(descriptors.data,
-                                            descriptors.cols,
-                                            descriptors.rows)
+      Eigen::Map<const VisualFrame::DescriptorsT>(descriptors.data,
+                                                  descriptors.cols,
+                                                  descriptors.rows)
   );
 
   // The keypoint uncertainty is set to a constant value.

--- a/aslam_cv_tracker/include/aslam/tracker/feature-tracker-gyro.h
+++ b/aslam_cv_tracker/include/aslam/tracker/feature-tracker-gyro.h
@@ -53,7 +53,8 @@ class GyroTracker : public FeatureTracker{
   ///                          compute descriptors for optical flow tracked keypoints.
   explicit GyroTracker(const Camera& camera,
                        const size_t min_distance_to_image_border,
-                       const cv::Ptr<cv::DescriptorExtractor>& extractor_ptr);
+                       const cv::Ptr<cv::DescriptorExtractor>& extractor_ptr,
+                       int descriptor_type = 0);
   virtual ~GyroTracker() {}
 
   /// \brief Track features between the current and the previous frames using a given interframe
@@ -152,6 +153,11 @@ class GyroTracker : public FeatureTracker{
   /// Status track length refers to the track length
   /// since the status of the feature has changed.
   FrameStatusTrackLength status_track_length_km1_;
+  /// Feature type to track, used to support multiple feature types in
+  /// frames. The returned matches will be with respect to the indices
+  /// of the descriptor type. To obtain the index offset with respect to the
+  /// entire keypoint block use VisualFrame::getDescriptorBlockTypeStartAndSize
+  int descriptor_type_;
 
   const GyroTrackerSettings settings_;
 };

--- a/aslam_cv_tracker/src/tracking-helpers.cc
+++ b/aslam_cv_tracker/src/tracking-helpers.cc
@@ -80,7 +80,7 @@ void insertCvKeypointsAndDescriptorsIntoEmptyVisualFrame(
 
   frame->setDescriptors(
       // Switch cols/rows as Eigen is col-major and cv::Mat is row-major.
-      Eigen::Map<aslam::VisualFrame::DescriptorsT>(
+      Eigen::Map<const aslam::VisualFrame::DescriptorsT>(
           new_cv_descriptors.data, new_cv_descriptors.cols, new_cv_descriptors.rows));
 }
 


### PR DESCRIPTION
Adding any number of new visual features to the aslam feature channels:
- The external API should remain mostly the same when using just one feature type
- New function that `extend` the frame by adding a new block of features. The default assumption is that each keypoint has at least a 2D image measurement. Other properties after that are optional.
- Corresponding functions to get keypoint properties for a certain feature type.
- Initial support for adding 3D measurements to keypoints (for example from a LiDAR or a RGBD sensor)