### PR TITLE
fix aslam_cv_cameras failing to find generated protobuf

### DIFF
--- a/aslam_cv_common/CMakeLists.txt
+++ b/aslam_cv_common/CMakeLists.txt
@@ -81,3 +81,4 @@ target_link_libraries(test_descriptor_utils ${catkin_LIBRARIES})
 ##########
 cs_install()
 cs_export(CFG_EXTRAS detect_simd.cmake export_flags.cmake setup_openmp.cmake)
+cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include)


### PR DESCRIPTION
This PR contains fix to solve this compilation errors:

```
_______________________________________________________________________________
Errors << aslam_cv_cameras:make /catkin_ws/logs/aslam_cv_cameras/build.make.000.log
In file included from /catkin_ws/src/aslam_cv2/aslam_cv_common/include/aslam/common/unique-id.h:12:0,
                 from /catkin_ws/src/aslam_cv2/aslam_cv_common/include/aslam/common/sensor.h:7,
                 from /catkin_ws/src/aslam_cv2/aslam_cv_cameras/include/aslam/cameras/camera.h:16,
                 from /catkin_ws/src/aslam_cv2/aslam_cv_cameras/include/aslam/cameras/camera-3d-lidar.h:4,
                 from /catkin_ws/src/aslam_cv2/aslam_cv_cameras/src/camera-3d-lidar.cc:1:
/catkin_ws/src/aslam_cv2/aslam_cv_common/include/aslam/common/internal/unique-id.h:7:10: fatal error: aslam/common/id.pb.h: No such file or directory
 #include "aslam/common/id.pb.h"
          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/aslam_cv_cameras.dir/src/camera-3d-lidar.cc.o] Error 1
make[1]: *** [CMakeFiles/aslam_cv_cameras.dir/all] Error 2
make: *** [all] Error 2
cd /catkin_ws/build/aslam_cv_cameras; catkin build --get-env aslam_cv_cameras | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
...............................................................................
Failed << aslam_cv_cameras:make                                 [ Exited with code 2 ]
```

Basically aslam_cv_cameras failing because it can't find the generated protobuf file.

This PR added the protobuf header from ${CATKIN_DEVEL_PREFIX}/include, similar to what's been done [here at voxblox](https://github.com/ethz-asl/voxblox/blob/master/voxblox/CMakeLists.txt#L142)